### PR TITLE
fix chat scroll to bottom and textwrap and chat page layout

### DIFF
--- a/web/src/chat/chat-page.html
+++ b/web/src/chat/chat-page.html
@@ -146,7 +146,7 @@
     #container {
       display: flex;
       flex-grow: 1;
-      flex-direction: column;
+      flex-direction: row
     }
     .chat-window {
       width: 100%;

--- a/web/src/chat/chat-room.html
+++ b/web/src/chat/chat-room.html
@@ -105,6 +105,10 @@
           let scrollBuffer = 60;
           if (currentPosition >= scrollHeight - scrollBuffer) {
             this.async(() => {
+              // Call render() so that the newly received message is displayed 
+              // before scrollHeight is calculated so we scroll to the bottom 
+              // of the new message.
+              this.$.renderedMessages.render();
               this.$.conversationContainer.scrollTop =
                   this.$.conversationContainer.scrollHeight;
             });
@@ -443,7 +447,7 @@
       flex-grow: 1;
       position: relative;
       padding-right: 16px;
-      word-break: break-all;
+      word-break: break-word;
     }
     #forWebdriver { height: 1px; }
     .request-input {
@@ -564,7 +568,7 @@
     </div>
 
     <div id="conversationContainer" class="conversation-container">
-      <template is="dom-repeat" items="[[chatRoom.messages]]">
+      <template id="renderedMessages" is="dom-repeat" items="[[chatRoom.messages]]">
         <div name$="message-[[chatRoom.name]]-[[item.message]]"
           class$="[[computeMessageDisplayClass_(item.playerId, currentPlayer.id)]] [[displaySenderInfo(item.playerId)]]">
           <div class="display-message">


### PR DESCRIPTION
Chat scrolling broke because it wasn't scrolling all the way to the bottom because scrollHeight was calculated before the new message was added to the chat window. After long enough messages, this made the code think that the user had intentionally scrolled higher and therefore wouldn't try to scroll to the bottom. Rendering on every message does have some cost since we lose the asynchronicity polymer dom-repeat normally gives us. 

https://www.polymer-project.org/2.0/docs/devguide/templates#synchronous-renders