### PR TITLE
Fix leaderboard sort stability

### DIFF
--- a/web/src/leaderboard/leaderboard-summary.html
+++ b/web/src/leaderboard/leaderboard-summary.html
@@ -51,7 +51,8 @@
       },
 
       sort_(playerA, playerB) {
-        return playerB.points - playerA.points;
+        return (playerB.points - playerA.points) ||
+            (playerA.id > playerB.id ? 1 : -1);
       },
 
       // filter_(player) {


### PR DESCRIPTION
Currently, the leaderboard summary (top 3) on the Dashboard (web version) does not match the top 3 players on the Leaderboard tab.

This is because the template sorting functionality relies on the JS native sort, which does not perform stable sorting. Adding a unique key (`id`) to the sort's comparison function will produce a stable sorting order.

This new functionality will sort by `points` descending, with a secondary sort on player `id` ascending. This produces a leaderboard summary which will match up with the Leaderboard tab.