### PR TITLE
Add ability to see chat messages in android

### DIFF
--- a/Android/ghvzApp/.idea/navEditor.xml
+++ b/Android/ghvzApp/.idea/navEditor.xml
@@ -13,6 +13,11 @@
                       <LayoutPositions />
                     </value>
                   </entry>
+                  <entry key="action_global_nav_chat_room_fragment">
+                    <value>
+                      <LayoutPositions />
+                    </value>
+                  </entry>
                   <entry key="action_global_nav_game_dashboard_fragment">
                     <value>
                       <LayoutPositions />
@@ -34,6 +39,18 @@
                     </value>
                   </entry>
                   <entry key="nav_chat_list_fragment">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="12" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="nav_chat_room_fragment">
                     <value>
                       <LayoutPositions>
                         <option name="myPosition">

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Message.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Message.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.firebase.classmodels
+
+import com.google.firebase.Timestamp
+
+/** Android data model representing Firebase Chat Message documents. */
+class Message {
+    companion object {
+        val FIELD__TIMESTAMP = "timestamp"
+    }
+
+    var id: String? = null
+
+    var message: String = ""
+    var senderId: String = ""
+    var timestamp: Timestamp? = null
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/operations/ChatDatabaseOperations.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/operations/ChatDatabaseOperations.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import com.app.playhvz.firebase.constants.ChatPath
 import com.app.playhvz.firebase.constants.PlayerPath
 import com.app.playhvz.firebase.firebaseprovider.FirebaseProvider
+import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -34,6 +35,14 @@ class ChatDatabaseOperations {
             chatRoomId: String
         ): DocumentReference {
             return ChatPath.CHAT_DOCUMENT_REFERENCE(gameId, chatRoomId)
+        }
+
+        /** Returns a collection reference to the given chatRoomId. */
+        fun getChatRoomMessagesReference(
+            gameId: String,
+            chatRoomId: String
+        ): CollectionReference {
+            return ChatPath.MESSAGE_COLLECTION(gameId, chatRoomId)
         }
 
         /** Check if game exists and tries to add player to game if so. */

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/utils/DataConverterUtil.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/utils/DataConverterUtil.kt
@@ -18,6 +18,7 @@ package com.app.playhvz.firebase.utils
 
 import com.app.playhvz.firebase.classmodels.ChatRoom
 import com.app.playhvz.firebase.classmodels.Game
+import com.app.playhvz.firebase.classmodels.Message
 import com.app.playhvz.firebase.classmodels.Player
 import com.google.firebase.firestore.DocumentSnapshot
 
@@ -35,14 +36,16 @@ class DataConverterUtil {
             return player
         }
 
-        fun convertSnapshotToPlayerPublicData(document: DocumentSnapshot): Player {
-            return document.toObject(Player::class.java)!!
-        }
-
         fun convertSnapshotToChatRoom(document: DocumentSnapshot): ChatRoom {
             val chatRoom = document.toObject(ChatRoom::class.java)!!
             chatRoom.id = document.id
             return chatRoom
+        }
+
+        fun convertSnapshotToMessage(document: DocumentSnapshot): Message {
+            val message = document.toObject(Message::class.java)!!
+            message.id = document.id
+            return message
         }
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/navigation/NavigationUtil.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/navigation/NavigationUtil.kt
@@ -19,7 +19,7 @@ package com.app.playhvz.navigation
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavController
 import com.app.playhvz.common.globals.SharedPreferencesConstants
-import com.app.playhvz.screens.chatRoom.ChatRoomFragmentDirections
+import com.app.playhvz.screens.chatroom.ChatRoomFragmentDirections
 import com.app.playhvz.screens.chatlist.ChatListFragmentDirections
 import com.app.playhvz.screens.gamedashboard.GameDashboardFragmentDirections
 import com.app.playhvz.screens.gamelist.GameListFragmentDirections

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/MessageAdapter.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/MessageAdapter.kt
@@ -14,31 +14,25 @@
  * limitations under the License.
  */
 
-package com.app.playhvz.screens.chatRoom
+package com.app.playhvz.screens.chatroom
 
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.app.playhvz.R
-import com.app.playhvz.firebase.classmodels.ChatRoom
-import com.app.playhvz.screens.chatlist.ChatRoomViewHolder
+import com.app.playhvz.firebase.classmodels.Message
 
 class MessageAdapter(
-    private var items: List<ChatRoom>,
-    val context: Context,
-    val navigator: IFragmentNavigator
+    private var items: List<Message>,
+    val context: Context
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    interface IFragmentNavigator {
-        fun onChatroomClicked(chatroomId: String)
-    }
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return ChatRoomViewHolder(
+        return MessageViewHolder(
             LayoutInflater.from(context).inflate(
-                R.layout.list_item_chat_list_chatroom,
+                R.layout.list_item_chat_room_message,
                 parent,
                 false
             )
@@ -46,15 +40,14 @@ class MessageAdapter(
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        //(holder as ChatRoomViewHolder).onBind(items[position], navigator)
+        (holder as MessageViewHolder).onBind(items[position])
     }
 
     override fun getItemCount(): Int {
         return items.size
     }
 
-    fun setData(data: List<ChatRoom>) {
-
+    fun setData(data: List<Message>) {
         items = data
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/MessageViewHolder.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/MessageViewHolder.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.screens.chatroom
+
+import android.view.View
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.app.playhvz.R
+import com.app.playhvz.firebase.classmodels.ChatRoom
+import com.app.playhvz.firebase.classmodels.Message
+
+class MessageViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
+
+    private var message: Message? = null
+    private val messageView = view.findViewById<TextView>(R.id.message)!!
+
+    fun onBind(message: Message) {
+        this.message = message
+        messageView.text = message.message
+    }
+}

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_chat_room.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_chat_room.xml
@@ -19,7 +19,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  tools:context=".screens.chatRoom.ChatRoomFragment">
+  tools:context=".screens.chatroom.ChatRoomFragment">
 
   <ProgressBar
     android:id="@+id/progress_bar"
@@ -36,16 +36,16 @@
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/message_list"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/screen_margin_horizontal"
     android:layout_marginEnd="@dimen/screen_margin_horizontal"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
     app:layout_constraintBottom_toTopOf="@+id/divider"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintHorizontal_bias="1.0"
+    app:layout_constraintHeight_default="spread"
+    app:layout_constraintHorizontal_bias="0.0"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_bias="0.843" />
+    app:layout_constraintTop_toBottomOf="@id/progress_bar" />
 
   <View
     android:id="@+id/divider"

--- a/Android/ghvzApp/app/src/main/res/layout/list_item_chat_room_message.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/list_item_chat_room_message.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:paddingTop="12dp"
+  android:paddingBottom="12dp">
+
+  <androidx.emoji.widget.EmojiTextView
+    android:id="@+id/message"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textColor="@color/app_primary_text"
+    android:textSize="@dimen/list_item_title_text" />
+
+</LinearLayout>

--- a/Android/ghvzApp/app/src/main/res/navigation/nav_graph.xml
+++ b/Android/ghvzApp/app/src/main/res/navigation/nav_graph.xml
@@ -113,7 +113,7 @@
 
   <fragment
     android:id="@+id/nav_chat_room_fragment"
-    android:name="com.app.playhvz.screens.chatRoom.ChatRoomFragment">
+    android:name="com.app.playhvz.screens.chatroom.ChatRoomFragment">
     <argument
       android:name="chatRoomId"
       app:argType="string"


### PR DESCRIPTION
Adds firestore listeners and view updates so that old and new chat messages are
visible in the chat room. A large amount of polish is still needed. The message
recycler view sizing isn't right and we still need to fix the keyboard toggle
logic.