### PR TITLE
Make sure to unregister firebase listeners when fragments die

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/app/HvzData.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/app/HvzData.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.app
+
+import androidx.lifecycle.MutableLiveData
+
+
+class HvzData<T>() : MutableLiveData<T>() {
+    var onDestroyed = {}
+
+    override fun onInactive() {
+        onDestroyed
+        super.onInactive()
+    }
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatRoomViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatRoomViewModel.kt
@@ -19,8 +19,8 @@ package com.app.playhvz.firebase.viewmodels
 import android.util.Log
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.app.playhvz.app.HvzData
 import com.app.playhvz.firebase.classmodels.ChatRoom
 import com.app.playhvz.firebase.classmodels.Message
 import com.app.playhvz.firebase.classmodels.Message.Companion.FIELD__TIMESTAMP
@@ -37,8 +37,8 @@ class ChatRoomViewModel : ViewModel() {
         private val TAG = ChatRoomViewModel::class.qualifiedName
     }
 
-    private var chatRoom: MutableLiveData<ChatRoom> = MutableLiveData()
-    private var messageList: MutableLiveData<List<Message>> = MutableLiveData()
+    private var chatRoom: HvzData<ChatRoom> = HvzData()
+    private var messageList: HvzData<List<Message>> = HvzData()
 
     /** Listens to a player's chat room membership updates and returns a LiveData object listing
      * the ids of the chat rooms the player is currently in. */
@@ -47,7 +47,7 @@ class ChatRoomViewModel : ViewModel() {
         gameId: String,
         chatRoomId: String
     ): LiveData<ChatRoom> {
-        getChatRoomDocumentReference(gameId, chatRoomId).addSnapshotListener(
+        val listener = getChatRoomDocumentReference(gameId, chatRoomId).addSnapshotListener(
             EventListener<DocumentSnapshot> { snapshot, e ->
                 if (e != null) {
                     Log.w(TAG, "ChatRoom listen failed. ", e)
@@ -58,6 +58,9 @@ class ChatRoomViewModel : ViewModel() {
                 }
                 chatRoom.value = DataConverterUtil.convertSnapshotToChatRoom(snapshot)
             })
+        chatRoom.onDestroyed = {
+            listener.remove()
+        }
         return chatRoom
     }
 
@@ -67,7 +70,7 @@ class ChatRoomViewModel : ViewModel() {
         gameId: String,
         chatRoomId: String
     ): LiveData<List<Message>> {
-        getChatRoomMessagesReference(gameId, chatRoomId).orderBy(
+        val listener = getChatRoomMessagesReference(gameId, chatRoomId).orderBy(
             FIELD__TIMESTAMP,
             Query.Direction.ASCENDING
         ).addSnapshotListener(
@@ -85,6 +88,9 @@ class ChatRoomViewModel : ViewModel() {
                 }
                 messageList.value = updatedList
             })
+        messageList.onDestroyed = {
+            listener.remove()
+        }
         return messageList
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/GameListViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/GameListViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.app.playhvz.app.EspressoIdlingResource
+import com.app.playhvz.app.HvzData
 import com.app.playhvz.firebase.classmodels.Game
 import com.app.playhvz.firebase.operations.GameDatabaseOperations.Companion.getGameByCreatorQuery
 import com.app.playhvz.firebase.operations.GameDatabaseOperations.Companion.getGameByPlayerQuery
@@ -39,12 +40,12 @@ class GameListViewModel : ViewModel() {
         private val TAG = GameListViewModel::class.qualifiedName
     }
 
-    private var ownedGames: MutableLiveData<List<Game>> = MutableLiveData()
-    private var participantGames: MutableLiveData<List<Game>> = MutableLiveData()
+    private var ownedGames: HvzData<List<Game>> = HvzData()
+    private var participantGames: HvzData<List<Game>> = HvzData()
 
 
     fun getOwnedGames(): LiveData<List<Game>> {
-        getGameByCreatorQuery()?.addSnapshotListener(EventListener<QuerySnapshot> { snapshot, e ->
+        val listener = getGameByCreatorQuery()?.addSnapshotListener(EventListener<QuerySnapshot> { snapshot, e ->
             if (e != null) {
                 Log.w(TAG, "Listen failed. ", e)
                 ownedGames.value = emptyList()
@@ -57,12 +58,14 @@ class GameListViewModel : ViewModel() {
             }
             ownedGames.value = ownedGamesList
         })
-
+        ownedGames.onDestroyed = {
+            listener?.remove()
+        }
         return ownedGames
     }
 
     fun getParticipantGames(): MutableLiveData<List<Game>> {
-        getGameByPlayerQuery()?.addSnapshotListener(EventListener<QuerySnapshot> { snapshot, e ->
+        val listener = getGameByPlayerQuery()?.addSnapshotListener(EventListener<QuerySnapshot> { snapshot, e ->
             if (e != null) {
                 Log.w(TAG, "Listen failed. ", e)
                 participantGames.value = emptyList()
@@ -92,7 +95,9 @@ class GameListViewModel : ViewModel() {
                 participantGames.value = asyncParticipantGamesList
             }
         })
-
+        participantGames.onDestroyed = {
+            listener?.remove()
+        }
         return participantGames
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/GameViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/GameViewModel.kt
@@ -17,8 +17,10 @@
 package com.app.playhvz.firebase.viewmodels
 
 import android.util.Log
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.app.playhvz.app.HvzData
 import com.app.playhvz.firebase.classmodels.Game
 import com.app.playhvz.firebase.constants.GamePath
 import com.app.playhvz.firebase.utils.DataConverterUtil
@@ -28,11 +30,11 @@ class GameViewModel : ViewModel() {
         private val TAG = GameViewModel::class.qualifiedName
     }
 
-    private var game: MutableLiveData<Game> = MutableLiveData()
+    private var game: HvzData<Game> = HvzData()
 
     /** Returns a Game LiveData object for the given id. */
-    fun getGame(gameId: String): MutableLiveData<Game> {
-        GamePath.GAMES_COLLECTION.document(gameId)
+    fun getGame(gameId: String): LiveData<Game> {
+        val listener = GamePath.GAMES_COLLECTION.document(gameId)
             .addSnapshotListener { snapshot, e ->
                 if (e != null) {
                     Log.w(TAG, "Listen failed.", e)
@@ -42,6 +44,9 @@ class GameViewModel : ViewModel() {
                     game.value = DataConverterUtil.convertSnapshotToGame(snapshot)
                 }
             }
+        game.onDestroyed = {
+            listener.remove()
+        }
         return game
     }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/utils/PlayerUtil.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/utils/PlayerUtil.kt
@@ -17,17 +17,18 @@
 package com.app.playhvz.utils
 
 import android.util.Log
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.LiveData
+import com.app.playhvz.app.HvzData
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.DEAD_ALLEGIANCES
 import com.app.playhvz.firebase.classmodels.Player
 import com.app.playhvz.firebase.constants.PlayerPath
 import com.app.playhvz.firebase.utils.DataConverterUtil
-import com.app.playhvz.firebase.viewmodels.PlayerViewModel
 
 
 class PlayerUtil {
     companion object {
         val TAG = PlayerUtil::class.qualifiedName
+
         enum class AliveStatus { ALIVE, DEAD }
 
         /** Returns whether the current player allegiance is considered Alive or Dead. */
@@ -40,10 +41,10 @@ class PlayerUtil {
         }
 
         /** Returns a Player LiveData object for the given id. */
-        fun getPlayer(gameId: String, playerId: String): MutableLiveData<Player> {
-            val player: MutableLiveData<Player> = MutableLiveData()
+        fun getPlayer(gameId: String, playerId: String): LiveData<Player> {
+            val player: HvzData<Player> = HvzData()
             player.value = Player()
-            PlayerPath.PLAYERS_COLLECTION(gameId).document(playerId)
+            val listener = PlayerPath.PLAYERS_COLLECTION(gameId).document(playerId)
                 .addSnapshotListener { snapshot, e ->
                     if (e != null) {
                         Log.w(TAG, "Listen failed.", e)
@@ -54,6 +55,9 @@ class PlayerUtil {
 
                     }
                 }
+            player.onDestroyed = {
+                listener.remove()
+            }
             return player
         }
     }


### PR DESCRIPTION
Created a custom LiveData object with a callback that will trigger when the
observer dies. At that point we can assume the fragment is destroyed and should
make sure to clean up our firebase listeners that were observing snapshots.