### PR TITLE
Fix firestore snapshot listener unregistration

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/app/HvzData.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/app/HvzData.kt
@@ -17,13 +17,17 @@
 package com.app.playhvz.app
 
 import androidx.lifecycle.MutableLiveData
+import com.google.firebase.firestore.ListenerRegistration
 
 
 class HvzData<T>() : MutableLiveData<T>() {
-    var onDestroyed = {}
+    val docIdListeners = mutableMapOf<String, ListenerRegistration>()
 
     override fun onInactive() {
-        onDestroyed
+        for (id in docIdListeners.keys) {
+            docIdListeners[id]?.remove()
+        }
+        docIdListeners.clear()
         super.onInactive()
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/ChatRoom.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/ChatRoom.kt
@@ -25,7 +25,7 @@ class ChatRoom {
     var id: String? = null
 
     // Group id
-    var groupId: String? = null
+    var associatedGroupId: String? = null
 
     var name: String = ""
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/operations/GameDatabaseOperations.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/operations/GameDatabaseOperations.kt
@@ -115,7 +115,7 @@ class GameDatabaseOperations {
             }
 
         /** Returns a Query listing all Games created by the current user. */
-        fun getGameByCreatorQuery(): Query? {
+        fun getGameByCreatorQuery(): Query {
             return GAMES_COLLECTION.whereEqualTo(
                 GAME_FIELD__CREATOR_ID,
                 FirebaseProvider.getFirebaseAuth().uid
@@ -123,7 +123,7 @@ class GameDatabaseOperations {
         }
 
         /** Returns a Query listing all Games in which the current user is a player. */
-        fun getGameByPlayerQuery(): Query? {
+        fun getGameByPlayerQuery(): Query {
             return PlayerPath.PLAYERS_QUERY.whereEqualTo(
                 UNIVERSAL_FIELD__USER_ID,
                 FirebaseProvider.getFirebaseAuth().uid

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatListViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatListViewModel.kt
@@ -29,7 +29,6 @@ import com.app.playhvz.firebase.utils.DataConverterUtil
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.EventListener
-import com.google.firebase.firestore.ListenerRegistration
 
 class ChatListViewModel : ViewModel() {
     companion object {
@@ -37,94 +36,116 @@ class ChatListViewModel : ViewModel() {
     }
 
     private var chatRoomIdList: HvzData<List<String>> = HvzData()
-    private var chatRoomList: HvzData<List<ChatRoom>> = HvzData()
+    private var chatRoomList: HvzData<Map<String, ChatRoom?>> = HvzData()
 
     /** Listens to a player's chat room membership updates and returns a LiveData object listing
-     * the ids of the chat rooms the player is currently in. */
+     * the chat rooms the player is currently in. */
     fun getChatRoomList(
         lifecycleOwner: LifecycleOwner,
         gameId: String,
         playerId: String
-    ): LiveData<List<ChatRoom>> {
-        val listener = getPlayerDocumentReference(gameId, playerId).addSnapshotListener(
-            listenToChatRoomMembershipChanges()
-        )
+    ): LiveData<Map<String, ChatRoom?>> {
+        if (chatRoomIdList.hasObservers()) {
+            // We've already started observing
+            return chatRoomList
+        }
         chatRoomIdList.observe(lifecycleOwner, androidx.lifecycle.Observer { serverChatRoomIdList ->
             observeChatRooms(gameId, serverChatRoomIdList)
         })
-        chatRoomIdList.onDestroyed = {
-            listener.remove()
-        }
-        return chatRoomList
-    }
-
-    /** Should be called after {@link: getChatRoomIds}. Listens to updates on every chat room the
-     * player is a member of. */
-    private fun observeChatRooms(
-        gameId: String,
-        chatRoomIdList: List<String>
-    ): LiveData<List<ChatRoom>> {
-        val chatRoomListenerList = mutableListOf<ListenerRegistration>()
-        for (id in chatRoomIdList) {
-            chatRoomListenerList.add(
-                getChatRoomDocumentReference(gameId, id).addSnapshotListener(
-                    EventListener<DocumentSnapshot> { snapshot, e ->
-                        if (e != null) {
-                            Log.w(TAG, "ChatRoom listen failed. ", e)
-                            return@EventListener
-                        }
-                        if (snapshot == null) {
-                            return@EventListener
-                        }
-                        refreshChatRooms(gameId)
-                    })
-            )
-        }
-        chatRoomList.onDestroyed = {
-            for (listener in chatRoomListenerList) {
-                listener.remove()
-            }
-        }
+        listenToPlayerChatRoomIds(gameId, playerId)
         return chatRoomList
     }
 
     /** Registers an event listener that watches for chat membership changes on the player object. */
-    private fun listenToChatRoomMembershipChanges(): EventListener<DocumentSnapshot> {
-        return EventListener { snapshot, e ->
-            if (e != null) {
-                Log.w(TAG, "Listen to chat memberships failed. ", e)
-                chatRoomIdList.value = emptyList()
-                return@EventListener
-            }
-            val player = DataConverterUtil.convertSnapshotToPlayer(snapshot!!)
-            val chatRoomIds: MutableList<String> = mutableListOf()
-            for ((key, value) in player.chatRoomMemberships) {
-                if (value.getOrElse(FIELD__IS_VISIBLE) { false }) {
-                    chatRoomIds.add(key)
+    private fun listenToPlayerChatRoomIds(gameId: String, playerId: String) {
+        val chatRoomIdListener = getPlayerDocumentReference(gameId, playerId).addSnapshotListener(
+            EventListener { snapshot, e ->
+                if (e != null) {
+                    Log.w(TAG, "Listen to chat memberships failed. ", e)
+                    chatRoomIdList.value = emptyList()
+                    return@EventListener
                 }
+                val player = DataConverterUtil.convertSnapshotToPlayer(snapshot!!)
+                val chatRoomIds: MutableList<String> = mutableListOf()
+                for ((key, value) in player.chatRoomMemberships) {
+                    if (value.getOrElse(FIELD__IS_VISIBLE) { false }) {
+                        chatRoomIds.add(key)
+                    }
+                }
+                if (chatRoomList.value != null) {
+                    // Remove chat room listeners for rooms the user isn't a member of anymore.
+                    val removedRooms = chatRoomIds.toSet().minus(chatRoomIdList.value!!.toSet())
+                    stopListening(removedRooms)
+                }
+                chatRoomIdList.value = chatRoomIds
             }
-            chatRoomIdList.value = chatRoomIds
+        )
+        chatRoomIdList.docIdListeners[playerId] = chatRoomIdListener
+    }
+
+    /** Listens to updates on every chat room the player is a member of. */
+    private fun observeChatRooms(
+        gameId: String,
+        chatRoomIdList: List<String>
+    ): LiveData<Map<String, ChatRoom?>> {
+        val firstPass = chatRoomList.value == null
+        val initialList = mutableMapOf<String, ChatRoom?>()
+
+        for (id in chatRoomIdList) {
+            if (id in chatRoomList.docIdListeners) {
+                // We're already listening to this room
+                continue
+            }
+            if (firstPass) {
+                initialList[id] = null
+            }
+            chatRoomList.docIdListeners[id] = getChatRoomDocumentReference(gameId, id).addSnapshotListener(
+                EventListener<DocumentSnapshot> { snapshot, e ->
+                    if (e != null) {
+                        Log.w(TAG, "ChatRoom listen failed. ", e)
+                        return@EventListener
+                    }
+                    if (snapshot == null) {
+                        return@EventListener
+                    }
+                    val updatedChatRoom = DataConverterUtil.convertSnapshotToChatRoom(snapshot)
+                    val updatedRoomList = chatRoomList.value!!.toMutableMap()
+                    updatedRoomList[id] = updatedChatRoom
+                    chatRoomList.value = updatedRoomList
+                })
+        }
+        chatRoomList.value = initialList
+        return chatRoomList
+    }
+
+    private fun stopListening(removedIds: Set<String>) {
+        for (removedId in removedIds) {
+            if (!chatRoomList.docIdListeners.containsKey(removedId)) {
+                continue
+            }
+            chatRoomList.docIdListeners[removedId]?.remove()
+            chatRoomList.docIdListeners.remove(removedId)
         }
     }
 
-    /** One of the chat rooms got an update, we don't know which one so reload all of them. */
-    private fun refreshChatRooms(gameId: String) {
+    /** Reloads all chat rooms and waits for every one to be done. */
+    private fun refreshAllChatRooms(gameId: String) {
         val tasks = chatRoomIdList.value!!.map { chatRoomId ->
             getChatRoomDocumentReference(gameId, chatRoomId).get()
         }
         Tasks.whenAll(tasks).addOnCompleteListener { _ ->
-            val updatedList: MutableList<ChatRoom> = mutableListOf()
+            //val updatedList: MutableList<ChatRoom> = mutableListOf()
             for (task in tasks) {
                 if (task.isSuccessful) {
                     val snapshot = task.result
                     if (snapshot != null && snapshot.exists()) {
-                        updatedList.add(DataConverterUtil.convertSnapshotToChatRoom(snapshot))
+                        //updatedList.add(DataConverterUtil.convertSnapshotToChatRoom(snapshot))
                     }
                 } else {
                     Log.d(TAG, "Failed to get ChatRoom, ${task.exception}")
                 }
             }
-            chatRoomList.value = updatedList
+            //chatRoomList.value = updatedList
         }
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatRoomViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatRoomViewModel.kt
@@ -47,20 +47,18 @@ class ChatRoomViewModel : ViewModel() {
         gameId: String,
         chatRoomId: String
     ): LiveData<ChatRoom> {
-        val listener = getChatRoomDocumentReference(gameId, chatRoomId).addSnapshotListener(
-            EventListener<DocumentSnapshot> { snapshot, e ->
-                if (e != null) {
-                    Log.w(TAG, "ChatRoom listen failed. ", e)
-                    return@EventListener
-                }
-                if (snapshot == null) {
-                    return@EventListener
-                }
-                chatRoom.value = DataConverterUtil.convertSnapshotToChatRoom(snapshot)
-            })
-        chatRoom.onDestroyed = {
-            listener.remove()
-        }
+        chatRoom.docIdListeners[chatRoomId] =
+            getChatRoomDocumentReference(gameId, chatRoomId).addSnapshotListener(
+                EventListener<DocumentSnapshot> { snapshot, e ->
+                    if (e != null) {
+                        Log.w(TAG, "ChatRoom listen failed. ", e)
+                        return@EventListener
+                    }
+                    if (snapshot == null) {
+                        return@EventListener
+                    }
+                    chatRoom.value = DataConverterUtil.convertSnapshotToChatRoom(snapshot)
+                })
         return chatRoom
     }
 
@@ -70,27 +68,25 @@ class ChatRoomViewModel : ViewModel() {
         gameId: String,
         chatRoomId: String
     ): LiveData<List<Message>> {
-        val listener = getChatRoomMessagesReference(gameId, chatRoomId).orderBy(
-            FIELD__TIMESTAMP,
-            Query.Direction.ASCENDING
-        ).addSnapshotListener(
-            EventListener<QuerySnapshot> { snapshot, e ->
-                if (e != null) {
-                    Log.w(TAG, "Message collection listen failed. ", e)
-                    return@EventListener
-                }
-                if (snapshot == null) {
-                    return@EventListener
-                }
-                val updatedList: MutableList<Message> = mutableListOf()
-                for (doc in snapshot.documents) {
-                    updatedList.add(DataConverterUtil.convertSnapshotToMessage(doc))
-                }
-                messageList.value = updatedList
-            })
-        messageList.onDestroyed = {
-            listener.remove()
-        }
+        messageList.docIdListeners[chatRoomId] =
+            getChatRoomMessagesReference(gameId, chatRoomId).orderBy(
+                FIELD__TIMESTAMP,
+                Query.Direction.ASCENDING
+            ).addSnapshotListener(
+                EventListener<QuerySnapshot> { snapshot, e ->
+                    if (e != null) {
+                        Log.w(TAG, "Message collection listen failed. ", e)
+                        return@EventListener
+                    }
+                    if (snapshot == null) {
+                        return@EventListener
+                    }
+                    val updatedList: MutableList<Message> = mutableListOf()
+                    for (doc in snapshot.documents) {
+                        updatedList.add(DataConverterUtil.convertSnapshotToMessage(doc))
+                    }
+                    messageList.value = updatedList
+                })
         return messageList
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/GameViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/GameViewModel.kt
@@ -34,7 +34,7 @@ class GameViewModel : ViewModel() {
 
     /** Returns a Game LiveData object for the given id. */
     fun getGame(gameId: String): LiveData<Game> {
-        val listener = GamePath.GAMES_COLLECTION.document(gameId)
+        game.docIdListeners[gameId] = GamePath.GAMES_COLLECTION.document(gameId)
             .addSnapshotListener { snapshot, e ->
                 if (e != null) {
                     Log.w(TAG, "Listen failed.", e)
@@ -44,9 +44,6 @@ class GameViewModel : ViewModel() {
                     game.value = DataConverterUtil.convertSnapshotToGame(snapshot)
                 }
             }
-        game.onDestroyed = {
-            listener.remove()
-        }
         return game
     }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/PlayerViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/PlayerViewModel.kt
@@ -37,7 +37,7 @@ class PlayerViewModel : ViewModel() {
     /** Returns a Player LiveData object for the given id. */
     fun getPlayer(gameId: String, playerId: String): LiveData<Player> {
         player.value = Player()
-        val listener = PlayerPath.PLAYERS_COLLECTION(gameId).document(playerId)
+        player.docIdListeners[playerId] = PlayerPath.PLAYERS_COLLECTION(gameId).document(playerId)
             .addSnapshotListener { snapshot, e ->
                 if (e != null) {
                     Log.w(TAG, "Listen failed.", e)
@@ -48,9 +48,6 @@ class PlayerViewModel : ViewModel() {
 
                 }
             }
-        player.onDestroyed = {
-            listener.remove()
-        }
         return player
     }
 
@@ -62,7 +59,7 @@ class PlayerViewModel : ViewModel() {
             Log.w(TAG, "Player Id was empty and shouldn't be, not listening to data updates.")
             return player
         }
-        val listener = PlayerPath.PLAYERS_COLLECTION(gameId)
+        player.docIdListeners["query"] = PlayerPath.PLAYERS_COLLECTION(gameId)
             .whereEqualTo(UNIVERSAL_FIELD__USER_ID, playerId)
             .addSnapshotListener { snapshot, e ->
                 if (e != null) {
@@ -73,9 +70,6 @@ class PlayerViewModel : ViewModel() {
                     updatePlayerData(DataConverterUtil.convertSnapshotToPlayer(snapshot.documents[0]!!))
                 }
             }
-        player.onDestroyed = {
-            listener.remove()
-        }
         return player
     }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/ChatListAdapter.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/ChatListAdapter.kt
@@ -31,7 +31,7 @@ class ChatListAdapter(
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     interface IFragmentNavigator {
-        fun onChatroomClicked(chatroomId: String)
+        fun onChatRoomClicked(chatRoomId: String)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -52,8 +52,13 @@ class ChatListAdapter(
         return items.size
     }
 
-    fun setData(data: List<ChatRoom>) {
-
-        items = data
+    fun setData(data: Map<String, ChatRoom?>) {
+        val cleansedList = mutableListOf<ChatRoom>()
+        for ((_, value) in data) {
+            if (value != null) {
+                cleansedList.add(value)
+            }
+        }
+        items = cleansedList
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/ChatListFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/ChatListFragment.kt
@@ -85,7 +85,7 @@ class ChatListFragment : Fragment(), ChatListAdapter.IFragmentNavigator {
         return view
     }
 
-    override fun onChatroomClicked(chatRoomId: String) {
+    override fun onChatRoomClicked(chatRoomId: String) {
         NavigationUtil.navigateToChatRoom(findNavController(), chatRoomId)
     }
 
@@ -112,7 +112,7 @@ class ChatListFragment : Fragment(), ChatListAdapter.IFragmentNavigator {
     }
 
     /** Update data and notify view and adapter of change. */
-    private fun onChatRoomUpdated(updatedChatRoomList: List<ChatRoom>) {
+    private fun onChatRoomUpdated(updatedChatRoomList: Map<String, ChatRoom?>) {
         updateView()
         chatListAdapter.setData(updatedChatRoomList)
         chatListAdapter.notifyDataSetChanged()

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/ChatRoomViewHolder.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/ChatRoomViewHolder.kt
@@ -31,7 +31,7 @@ class ChatRoomViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
         this.chatRoom = chatRoom
         chatNameTextView.text = chatRoom.name
         itemView.setOnClickListener {
-            navigator.onChatroomClicked(chatRoom.id!!)
+            navigator.onChatRoomClicked(chatRoom.id!!)
         }
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/utils/PlayerUtil.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/utils/PlayerUtil.kt
@@ -44,20 +44,18 @@ class PlayerUtil {
         fun getPlayer(gameId: String, playerId: String): LiveData<Player> {
             val player: HvzData<Player> = HvzData()
             player.value = Player()
-            val listener = PlayerPath.PLAYERS_COLLECTION(gameId).document(playerId)
-                .addSnapshotListener { snapshot, e ->
-                    if (e != null) {
-                        Log.w(TAG, "Listen failed.", e)
-                        return@addSnapshotListener
-                    }
-                    if (snapshot != null && snapshot.exists()) {
-                        player.value = DataConverterUtil.convertSnapshotToPlayer(snapshot)
+            player.docIdListeners[playerId] =
+                PlayerPath.PLAYERS_COLLECTION(gameId).document(playerId)
+                    .addSnapshotListener { snapshot, e ->
+                        if (e != null) {
+                            Log.w(TAG, "Listen failed.", e)
+                            return@addSnapshotListener
+                        }
+                        if (snapshot != null && snapshot.exists()) {
+                            player.value = DataConverterUtil.convertSnapshotToPlayer(snapshot)
 
+                        }
                     }
-                }
-            player.onDestroyed = {
-                listener.remove()
-            }
             return player
         }
     }


### PR DESCRIPTION
Makes sure to unregister firebase listeners, especially in the chat list where
it's possible we'll stop observing a chat room because the user isn't a member
anymore.

Also clean up ChatListViewModel to make it more straight forward.