### PR TITLE
Add skeleton chat info page fragment and hook it up

### DIFF
--- a/Android/ghvzApp/.idea/assetWizardSettings.xml
+++ b/Android/ghvzApp/.idea/assetWizardSettings.xml
@@ -205,8 +205,8 @@
                         <option name="values">
                           <map>
                             <entry key="assetSourceType" value="FILE" />
-                            <entry key="outputName" value="ic_send_24px" />
-                            <entry key="sourceFile" value="$USER_HOME$/Downloads/send-24px.svg" />
+                            <entry key="outputName" value="ic_info" />
+                            <entry key="sourceFile" value="$USER_HOME$/Downloads/info-24px.svg" />
                           </map>
                         </option>
                       </PersistentState>

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatRoomViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatRoomViewModel.kt
@@ -40,6 +40,10 @@ class ChatRoomViewModel : ViewModel() {
     private var chatRoom: HvzData<ChatRoom> = HvzData()
     private var messageList: HvzData<List<Message>> = HvzData()
 
+    fun getChatName(): String? {
+        return chatRoom.value?.name
+    }
+
     /** Listens to a player's chat room membership updates and returns a LiveData object listing
      * the ids of the chat rooms the player is currently in. */
     fun getChatRoomObserver(

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/navigation/NavigationUtil.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/navigation/NavigationUtil.kt
@@ -19,8 +19,9 @@ package com.app.playhvz.navigation
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavController
 import com.app.playhvz.common.globals.SharedPreferencesConstants
-import com.app.playhvz.screens.chatroom.ChatRoomFragmentDirections
 import com.app.playhvz.screens.chatlist.ChatListFragmentDirections
+import com.app.playhvz.screens.chatroom.ChatRoomFragmentDirections
+import com.app.playhvz.screens.chatroom.chatinfo.ChatInfoFragmentDirections
 import com.app.playhvz.screens.gamedashboard.GameDashboardFragmentDirections
 import com.app.playhvz.screens.gamelist.GameListFragmentDirections
 import com.app.playhvz.screens.gamesettings.GameSettingsFragmentDirections
@@ -94,5 +95,13 @@ class NavigationUtil {
             )
         }
 
+        /**
+         * Opens the chat's info screen.
+         */
+        fun navigateToChatInfo(navController: NavController, chatRoomId: String) {
+            navController.navigate(
+                ChatInfoFragmentDirections.actionGlobalNavChatInfoFragment(chatRoomId)
+            )
+        }
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/ChatRoomFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/ChatRoomFragment.kt
@@ -18,9 +18,7 @@ package com.app.playhvz.screens.chatroom
 
 import android.app.Activity
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.view.inputmethod.InputMethodManager
 import android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT
 import android.widget.ProgressBar
@@ -30,6 +28,7 @@ import androidx.core.widget.doOnTextChanged
 import androidx.emoji.widget.EmojiEditText
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -43,6 +42,7 @@ import com.app.playhvz.firebase.classmodels.Message
 import com.app.playhvz.firebase.classmodels.Player
 import com.app.playhvz.firebase.operations.ChatDatabaseOperations
 import com.app.playhvz.firebase.viewmodels.ChatRoomViewModel
+import com.app.playhvz.navigation.NavigationUtil
 import com.app.playhvz.utils.PlayerUtil
 import com.google.android.material.button.MaterialButton
 import kotlinx.coroutines.runBlocking
@@ -128,11 +128,29 @@ class ChatRoomFragment : Fragment() {
         hideKeyboard()
     }
 
+    override fun onResume() {
+        super.onResume()
+        val name = chatViewModel.getChatName()
+        if (name != null && name != toolbar?.title) {
+            toolbar?.title = name
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.menu_chat, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.chat_info) {
+            NavigationUtil.navigateToChatInfo(findNavController(), chatRoomId)
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
     fun setupToolbar() {
-        toolbar?.title = getString(R.string.chat_list_toolbar)
-        /*if (game == null || game?.name.isNullOrEmpty()) context!!.getString(R.string.game_settings_create_game_toolbar_title)
-        else game?.name */
+        toolbar?.title = ""
         toolbar?.setDisplayHomeAsUpEnabled(false)
+        setHasOptionsMenu(true)
     }
 
     private fun setupObservers() {
@@ -174,10 +192,6 @@ class ChatRoomFragment : Fragment() {
             return
         }
         progressBar.visibility = View.GONE
-    }
-
-    private fun createChat() {
-        // TODO: implement creating a new chat
     }
 
     private fun sendMessage() {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/chatinfo/ChatInfoFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/chatinfo/ChatInfoFragment.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.screens.chatroom.chatinfo
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ProgressBar
+import androidx.appcompat.app.ActionBar
+import androidx.appcompat.app.AppCompatActivity
+import androidx.emoji.widget.EmojiTextView
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
+import com.app.playhvz.R
+import com.app.playhvz.common.globals.SharedPreferencesConstants
+import com.app.playhvz.common.globals.SharedPreferencesConstants.Companion.CURRENT_GAME_ID
+import com.app.playhvz.common.globals.SharedPreferencesConstants.Companion.CURRENT_PLAYER_ID
+import com.app.playhvz.firebase.classmodels.ChatRoom
+import com.app.playhvz.firebase.viewmodels.ChatRoomViewModel
+
+/** Fragment for showing a list of Chatrooms the user is a member of.*/
+class ChatInfoFragment : Fragment() {
+    companion object {
+        private val TAG = ChatInfoFragment::class.qualifiedName
+    }
+
+    lateinit var chatViewModel: ChatRoomViewModel
+
+    private lateinit var chatRoomId: String
+    private lateinit var progressBar: ProgressBar
+    private lateinit var chatNameView: EmojiTextView
+
+    private val args: ChatInfoFragmentArgs by navArgs()
+    private var gameId: String? = null
+    private var playerId: String? = null
+    private var toolbar: ActionBar? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        chatRoomId = args.chatRoomId
+        chatViewModel = ChatRoomViewModel()
+
+        val sharedPrefs = activity?.getSharedPreferences(
+            SharedPreferencesConstants.PREFS_FILENAME,
+            0
+        )!!
+        gameId = sharedPrefs.getString(CURRENT_GAME_ID, null)
+        playerId = sharedPrefs.getString(CURRENT_PLAYER_ID, null)
+
+        toolbar = (activity as AppCompatActivity).supportActionBar
+        setupObservers()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_chat_info, container, false)
+        progressBar = view.findViewById(R.id.progress_bar)
+        chatNameView = view.findViewById(R.id.chat_name)
+        progressBar.visibility = View.GONE
+        setupToolbar()
+        return view
+    }
+
+    fun setupToolbar() {
+        toolbar?.title = getString(R.string.chat_info_title)
+        toolbar?.setDisplayHomeAsUpEnabled(false)
+    }
+
+    private fun setupObservers() {
+        if (gameId.isNullOrEmpty() || playerId.isNullOrEmpty()) {
+            return
+        }
+        chatViewModel.getChatRoomObserver(this, gameId!!, chatRoomId)
+            .observe(this, androidx.lifecycle.Observer { serverChatRoom ->
+                onChatRoomUpdated(serverChatRoom)
+            })
+        /*
+        chatViewModel.getMessagesObserver(this, gameId!!, chatRoomId)
+            .observe(this, androidx.lifecycle.Observer { serverMessageList ->
+                onMessagesUpdated(serverMessageList)
+            }) */
+    }
+
+    /** Update data and notify view and adapter of change. */
+    private fun onChatRoomUpdated(updatedChatRoom: ChatRoom) {
+        chatNameView.text = updatedChatRoom.name
+    }
+
+    private fun updateView() {
+        if (this.view == null) {
+            return
+        }
+        progressBar.visibility = View.GONE
+    }
+}

--- a/Android/ghvzApp/app/src/main/res/drawable/ic_info.xml
+++ b/Android/ghvzApp/app/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="#FFFFFFFF"
+    android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z" />
+</vector>

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_chat_info.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_chat_info.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical"
+  tools:context=".screens.chatroom.chatinfo.ChatInfoFragment">
+
+  <ProgressBar
+    android:id="@+id/progress_bar"
+    style="?android:attr/progressBarStyleHorizontal"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/horizontal_progress_bar_height"
+    android:indeterminate="true"
+    android:paddingStart="@dimen/screen_margin_horizontal"
+    android:paddingEnd="@dimen/screen_margin_horizontal" />
+
+  <androidx.emoji.widget.EmojiTextView
+    android:id="@+id/chat_name"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/screen_margin_horizontal"
+    android:textColor="@color/app_primary_text"
+    android:textSize="@dimen/list_item_title_text"
+    tools:text="Chat" />
+
+  <View
+    android:id="@+id/divider_top"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/divider_height"
+    android:background="@color/divider" />
+
+  <View
+    android:id="@+id/divider"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/divider_height"
+    android:background="@color/divider" />
+
+  <TextView
+    android:id="@+id/member_count"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
+    android:paddingStart="@dimen/screen_margin_horizontal"
+    android:paddingEnd="@dimen/screen_margin_horizontal"
+    android:text="0 members" />
+
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/member_list"
+    android:layout_width="match_parent"
+    android:layout_height="0dp"
+    android:layout_marginStart="@dimen/screen_margin_horizontal"
+    android:layout_marginEnd="@dimen/screen_margin_horizontal"
+    android:layout_weight="1"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    app:layout_constraintTop_toBottomOf="@+id/divider" />
+</LinearLayout>

--- a/Android/ghvzApp/app/src/main/res/menu/menu_chat.xml
+++ b/Android/ghvzApp/app/src/main/res/menu/menu_chat.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
+  <item
+    android:id="@+id/chat_info"
+    android:icon="@drawable/ic_info"
+    android:title="@string/chat_info_content_description"
+    app:showAsAction="always" />
+</menu>

--- a/Android/ghvzApp/app/src/main/res/navigation/nav_graph.xml
+++ b/Android/ghvzApp/app/src/main/res/navigation/nav_graph.xml
@@ -53,6 +53,9 @@
     android:id="@+id/action_global_nav_chat_room_fragment"
     app:destination="@id/nav_chat_room_fragment" />
 
+  <action
+    android:id="@+id/action_global_nav_chat_info_fragment"
+    app:destination="@id/nav_chat_info_fragment" />
 
   <fragment
     android:id="@+id/nav_game_dashboard_fragment"
@@ -120,4 +123,12 @@
       app:nullable="false" />
   </fragment>
 
+  <fragment
+    android:id="@+id/nav_chat_info_fragment"
+    android:name="com.app.playhvz.screens.chatroom.chatinfo.ChatInfoFragment">
+    <argument
+      android:name="chatRoomId"
+      app:argType="string"
+      app:nullable="false" />
+  </fragment>
 </navigation>

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -91,6 +91,10 @@
     Chat
   </string>
 
+  <string name="chat_info_title" definition="Title for the chat info page.">
+    Options
+  </string>
+
   <string name="chat_input_hint" definition="Hint text for chat room message input.">
     Message %1$s
   </string>
@@ -224,6 +228,10 @@
   </string>
 
   <!-- Accessibility strings -->
+  <string name="chat_info_content_description" definition="Content description for the icon to open chat info page.">
+    See chat info
+  </string>
+
   <string name="force_upgrade_image_content_description" definition="Content description for force upgrade image.">
     poo
   </string>

--- a/Android/ghvzApp/app/src/main/res/values/styles.xml
+++ b/Android/ghvzApp/app/src/main/res/values/styles.xml
@@ -17,13 +17,14 @@
 <resources>
 
   <!-- Base application theme. -->
-  <style name="AppTheme" parent="Theme.MaterialComponents.Light">
+  <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
     <!-- Customize your theme here. -->
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
     <item name="colorAccent">@color/colorAccent</item>
     <item name="windowNoTitle">true</item>
     <item name="windowActionBar">false</item>
+
   </style>
 
   <style name="HeaderText">


### PR DESCRIPTION
Adds a place holder activity for chat info so we can start adding people and
leaving chat rooms and seeing a list of members.