### PR TITLE
Filter players out of chat rooms when allegiance changes

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/CreateChatDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatlist/CreateChatDialog.kt
@@ -26,6 +26,8 @@ import androidx.emoji.widget.EmojiEditText
 import androidx.fragment.app.DialogFragment
 import com.app.playhvz.R
 import com.app.playhvz.app.EspressoIdlingResource
+import com.app.playhvz.common.globals.CrossClientConstants.Companion.HUMAN
+import com.app.playhvz.common.globals.CrossClientConstants.Companion.ZOMBIE
 import com.app.playhvz.firebase.operations.ChatDatabaseOperations
 import com.app.playhvz.utils.SystemUtils
 import kotlinx.coroutines.runBlocking
@@ -118,9 +120,9 @@ class CreateChatDialog(val gameId: String, val playerId: String) : DialogFragmen
         var allegianceFilter = "none"
         if (allegianceFilterCheckbox.isChecked) {
             allegianceFilter = if (allegianceHuman.isChecked) {
-                "human"
+                HUMAN
             } else {
-                "zombie"
+                ZOMBIE
             }
         }
         runBlocking {

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -72,11 +72,11 @@
   </string>
 
   <string name="chat_creation_radio_human" definition="Label for the radio button indicating human allegiance.">
-    Human
+    Resistance
   </string>
 
   <string name="chat_creation_radio_zombie" definition="Label for the radio button indicating zombie allegiance.">
-    Zombie
+    Horde
   </string>
 
   <string name="chat_creation_name_label" definition="Label for the chat room name input textview.">

--- a/firebaseFunctions/functions/src/utils/chatutils.ts
+++ b/firebaseFunctions/functions/src/utils/chatutils.ts
@@ -43,12 +43,29 @@ export async function addPlayerToChat(
             });
     }
 
-    console.log("Updated group")
-
     // We have to use dot-notation or firebase will overwrite the entire field.
     const membershipField = Player.FIELD__CHAT_MEMBERSHIPS + "." + chatRoomId
     const chatVisibility = {[Player.FIELD__CHAT_VISIBILITY]: true}
     await player.ref.update({
       [membershipField]: chatVisibility
     })
+}
+
+// Remove player from specified chat room and group
+export async function removePlayerFromChat(
+  db: any,
+  gameId: string,
+  player: any,
+  group: any,
+  chatRoomId: string
+) {
+  await group.ref.update({
+    [Group.FIELD__MEMBERS]: admin.firestore.FieldValue.arrayRemove(player.id)
+  });
+
+  // We have to use dot-notation or firebase will overwrite the entire field.
+  const membershipField = Player.FIELD__CHAT_MEMBERSHIPS + "." + chatRoomId
+  await player.ref.update({
+    [membershipField]: admin.firestore.FieldValue.delete()
+  })
 }


### PR DESCRIPTION
Adds support for removing players from chat rooms when their allegiance
changes. Fixes bug where creating a chat room didn't use the universal key words
for human and zombie for filtering wasn't correct.