### PR TITLE
Add allegiance selection to mission creation

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/globals/CrossClientConstants.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/globals/CrossClientConstants.kt
@@ -23,6 +23,7 @@ class CrossClientConstants {
         const val HUMAN = "resistance"
         const val ZOMBIE = "horde"
         const val UNDECLARED = "undeclared"
+        const val BLANK_ALLEGIANCE_FILTER = "none"
         val DEAD_ALLEGIANCES = arrayOf(ZOMBIE)
         const val ALIVE_COLOR: Int = Color.MAGENTA
         const val DEAD_COLOR: Int = Color.GREEN

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Mission.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Mission.kt
@@ -29,4 +29,6 @@ class Mission {
 
     var startTime: Long = EMPTY_TIMESTAMP
     var endTime: Long = EMPTY_TIMESTAMP
+
+    var associatedGroupId: String? = null
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doOnTextChanged
@@ -28,6 +29,10 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.app.playhvz.R
 import com.app.playhvz.common.DateTimePickerDialog
+import com.app.playhvz.common.globals.CrossClientConstants.Companion.BLANK_ALLEGIANCE_FILTER
+import com.app.playhvz.common.globals.CrossClientConstants.Companion.HUMAN
+import com.app.playhvz.common.globals.CrossClientConstants.Companion.UNDECLARED
+import com.app.playhvz.common.globals.CrossClientConstants.Companion.ZOMBIE
 import com.app.playhvz.common.globals.SharedPreferencesConstants
 import com.app.playhvz.firebase.classmodels.Mission
 import com.google.android.material.button.MaterialButton
@@ -40,11 +45,12 @@ class MissionSettingsFragment : Fragment() {
         private val TAG = MissionSettingsFragment::class.qualifiedName
     }
 
-    lateinit var nameText: EmojiEditText
-    lateinit var submitButton: MaterialButton
-    lateinit var startTime: TextView
-    lateinit var endTime: TextView
-    lateinit var missionDraft: Mission
+    private lateinit var nameText: EmojiEditText
+    private lateinit var submitButton: MaterialButton
+    private lateinit var startTime: TextView
+    private lateinit var endTime: TextView
+    private lateinit var missionDraft: Mission
+    private lateinit var allegianceRadioGroup: RadioGroup
 
     val args: MissionSettingsFragmentArgs by navArgs()
     var gameId: String? = null
@@ -73,6 +79,8 @@ class MissionSettingsFragment : Fragment() {
         submitButton = view.findViewById(R.id.submit_button)
         startTime = view.findViewById(R.id.mission_start_time)
         endTime = view.findViewById(R.id.mission_end_time)
+        allegianceRadioGroup = view!!.findViewById(R.id.radio_button_group)
+
         submitButton.setOnClickListener {
             submitMission()
         }
@@ -92,6 +100,8 @@ class MissionSettingsFragment : Fragment() {
         endTime.setOnClickListener { v ->
             openTimePicker(v as TextView)
         }
+
+        setupAllegianceButtons()
         return view
     }
 
@@ -113,8 +123,26 @@ class MissionSettingsFragment : Fragment() {
         }
     }
 
+    private fun setupAllegianceButtons() {
+        if (missionId != null) {
+            allegianceRadioGroup.isEnabled = false
+        }
+    }
+
     private fun submitMission() {
         val name = nameText.text
+
+        val selectedFilter = allegianceRadioGroup.checkedRadioButtonId
+
+        val allegianceFilter: String = if (selectedFilter == R.id.radio_human) {
+            HUMAN
+        } else if (selectedFilter == R.id.radio_zombie) {
+            ZOMBIE
+        } else if (selectedFilter == R.id.radio_undeclared) {
+            UNDECLARED
+        } else {
+            BLANK_ALLEGIANCE_FILTER
+        }
     }
 
     private fun openTimePicker(clickedView: TextView) {

--- a/Android/ghvzApp/app/src/main/res/layout/dialog_create_chat.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/dialog_create_chat.xml
@@ -90,14 +90,14 @@
       android:layout_height="wrap_content"
       android:checked="true"
       android:enabled="false"
-      android:text="@string/chat_creation_radio_human" />
+      android:text="@string/allegiance_option_human" />
 
     <RadioButton
       android:id="@+id/radio_zombie"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:enabled="false"
-      android:text="@string/chat_creation_radio_zombie" />
+      android:text="@string/allegiance_option_zombie" />
   </RadioGroup>
 
   <com.google.android.material.button.MaterialButton

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
@@ -100,6 +100,46 @@
       style="@style/TextInputLabel"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:text="@string/mission_settings_allegiance_label" />
+
+    <RadioGroup
+      android:id="@+id/radio_button_group"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="24dp"
+      android:orientation="vertical"
+      android:paddingBottom="16dp">
+
+      <RadioButton
+        android:id="@+id/radio_human"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/allegiance_option_human" />
+
+      <RadioButton
+        android:id="@+id/radio_zombie"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/allegiance_option_zombie" />
+
+      <RadioButton
+        android:id="@+id/radio_undeclared"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/allegiance_option_undeclared" />
+
+      <RadioButton
+        android:id="@+id/radio_everyone"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/allegiance_option_everyone" />
+    </RadioGroup>
+
+    <TextView
+      style="@style/TextInputLabel"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
       android:text="@string/mission_settings_details_label" />
 
     <androidx.emoji.widget.EmojiEditText

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -26,6 +26,21 @@
   <string name="default_notification_title">From HvZ CDC</string>
 
   <!-- String definitions, alphabetized. -->
+  <string name="allegiance_option_human" definition="Label for the radio button indicating human allegiance.">
+    Resistance
+  </string>
+
+  <string name="allegiance_option_zombie" definition="Label for the radio button indicating zombie allegiance.">
+    Horde
+  </string>
+
+  <string name="allegiance_option_undeclared" definition="Label for the radio button indicating undeclared allegiance.">
+    Undeclared
+  </string>
+
+  <string name="allegiance_option_everyone" definition="Label for the radio button indicating no allegiance filter.">
+    Everyone
+  </string>
 
   <string name="allegiance_status_alive" definition="Status indicating the player is alive.">
     Alive
@@ -69,14 +84,6 @@
 
   <string name="chat_creation_checkbox_allegiance" definition="Label for the checkbox indicating if the room has an allegiance filter.">
     Enforce members are only:
-  </string>
-
-  <string name="chat_creation_radio_human" definition="Label for the radio button indicating human allegiance.">
-    Resistance
-  </string>
-
-  <string name="chat_creation_radio_zombie" definition="Label for the radio button indicating zombie allegiance.">
-    Horde
   </string>
 
   <string name="chat_creation_name_label" definition="Label for the chat room name input textview.">
@@ -318,6 +325,10 @@
 
   <string name="mission_settings_details_label" definition="Label for mission details.">
     Details
+  </string>
+
+  <string name="mission_settings_allegiance_label" definition="Label for mission allegiance filter.">
+    Allegiance
   </string>
 
   <string name="navigation_drawer_game_dashboard" definition="Navigation drawer menu item for opening the dashboard of a game.">


### PR DESCRIPTION
Adds radio buttons for every allegiance and disables changing allegiance if the
user is editing an existing mission.