### PR TITLE
Firebase refactors and some mission polish stuff

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/MissionDashboardAdapter.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/MissionDashboardAdapter.kt
@@ -59,6 +59,8 @@ class MissionDashboardAdapter(
                 cleansedList.add(value)
             }
         }
+        cleansedList.sortBy { mission -> mission.endTime }
+        cleansedList.reverse()
         items = cleansedList
     }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
@@ -58,6 +58,7 @@ class MissionSettingsFragment : Fragment() {
     private lateinit var endTime: TextView
     private lateinit var missionDraft: Mission
     private lateinit var allegianceRadioGroup: RadioGroup
+    private lateinit var toolbarMenu: Menu
 
     val args: MissionSettingsFragmentArgs by navArgs()
     var gameId: String? = null
@@ -79,6 +80,7 @@ class MissionSettingsFragment : Fragment() {
                 OnSuccessListener { document ->
                     missionDraft = DataConverterUtil.convertSnapshotToMission(document)
                     initializeData()
+                    enableActions()
                 })
         }
         setupObservers()
@@ -104,10 +106,10 @@ class MissionSettingsFragment : Fragment() {
         nameText.doOnTextChanged { text, _, _, _ ->
             when {
                 text.isNullOrEmpty() || text.isBlank() -> {
-                    submitButton.isEnabled = false
+                    disableActions()
                 }
                 else -> {
-                    submitButton.isEnabled = true
+                    enableActions()
                 }
             }
         }
@@ -136,6 +138,8 @@ class MissionSettingsFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.menu_mission_settings, menu)
+        toolbarMenu = menu
+        disableActions()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -175,6 +179,7 @@ class MissionSettingsFragment : Fragment() {
     }
 
     private fun submitMission() {
+        disableActions()
         val name: String = nameText.text.toString()
         val details: String = detailText.text.toString()
 
@@ -205,6 +210,7 @@ class MissionSettingsFragment : Fragment() {
                         NavigationUtil.navigateToMissionDashboard(findNavController())
                     },
                     {
+                        enableActions()
                         SystemUtils.showToast(context, "Couldn't create mission.")
                     }
                 )
@@ -226,6 +232,7 @@ class MissionSettingsFragment : Fragment() {
                         NavigationUtil.navigateToMissionDashboard(findNavController())
                     },
                     {
+                        enableActions()
                         SystemUtils.showToast(context, "Couldn't update mission.")
                     }
                 )
@@ -256,6 +263,7 @@ class MissionSettingsFragment : Fragment() {
     }
 
     private fun showDeleteDialog() {
+        disableActions()
         val deleteDialog = ConfirmationDialog(
             getString(R.string.game_settings_delete_dialog_title, missionDraft.name),
             R.string.game_settings_delete_dialog_description,
@@ -275,6 +283,7 @@ class MissionSettingsFragment : Fragment() {
                             EspressoIdlingResource.decrement()
                         },
                         {
+                            enableActions()
                             SystemUtils.showToast(context, "Failed to mission")
                             EspressoIdlingResource.decrement()
                         }
@@ -282,6 +291,23 @@ class MissionSettingsFragment : Fragment() {
                 }
             }
         }
+        deleteDialog.setNegativeButtonCallback {
+            enableActions()
+        }
         activity?.supportFragmentManager?.let { deleteDialog.show(it, TAG) }
+    }
+
+    private fun disableActions() {
+        val menuItem = toolbarMenu.findItem(R.id.save_mission)
+        menuItem.icon.mutate().alpha = 130
+        menuItem.isEnabled = false
+        submitButton.isEnabled = false
+    }
+
+    private fun enableActions() {
+        val menuItem = toolbarMenu.findItem(R.id.save_mission)
+        menuItem.icon.mutate().alpha = 255
+        menuItem.isEnabled = true
+        submitButton.isEnabled = true
     }
 }

--- a/firebaseFunctions/functions/src/utils/grouputils.ts
+++ b/firebaseFunctions/functions/src/utils/grouputils.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+
+import * as Chat from '../data/chat';
+import * as ChatUtils from './chatutils';
+import * as Defaults from '../data/defaults';
+import * as Game from '../data/game';
+import * as Group from '../data/group';
+import * as Mission from '../data/mission';
+import * as Player from '../data/player';
+
+// Creates a group
+export async function createGlobalGroup(db: any, uid: any, gameId: string) {
+  const group = Group.createManagedGroup(
+    /* name= */ Defaults.globalChatName,
+    /* settings= */ Group.getGlobalGroupSettings(),
+  )
+  const createdGroup = await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Group.COLLECTION_PATH).add(group);
+  const chat = Chat.create(createdGroup.id, Defaults.globalChatName)
+  await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Chat.COLLECTION_PATH).add(chat)
+}
+
+// Creates a group and chat
+export async function createGroupAndChat(
+  db: any,
+  uid: any,
+  gameId: string,
+  playerId: string,
+  chatName: string,
+  settings: any
+) {
+  const group = Group.createPlayerOwnedGroup(
+    playerId,
+    chatName,
+    /* settings= */ settings,
+  )
+  const createdGroup = await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Group.COLLECTION_PATH).add(group);
+  const chat = Chat.create(createdGroup.id, chatName)
+  const createdChat = await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Chat.COLLECTION_PATH).add(chat)
+  await ChatUtils.addPlayerToChat(db, gameId, playerId, createdGroup, createdChat.id, /* isNewGroup= */ true)
+}
+
+// Creates a group and mission
+export async function createGroupAndMission(
+  db: any,
+  gameId: string,
+  settings: any,
+  missionName: string,
+  startTime: number,
+  endTime: number,
+  details: string,
+  allegianceFilter: string
+) {
+  const group = Group.createManagedGroup(missionName, settings)
+  const createdGroup = await db.collection(Game.COLLECTION_PATH)
+    .doc(gameId)
+    .collection(Group.COLLECTION_PATH)
+    .add(group);
+  const mission = Mission.create(
+    createdGroup.id,
+    missionName,
+    startTime,
+    endTime,
+    details,
+    allegianceFilter
+  )
+  await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Mission.COLLECTION_PATH).add(mission)
+  await updateMissionMembership(db, gameId, createdGroup.id)
+}
+
+
+// Add player to global chatroom
+export async function addNewPlayerToGroups(db: any, gameId: string, player: any) {
+  const groupQuery = await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Group.COLLECTION_PATH)
+  .where(Group.FIELD__MANAGED, "==", true)
+  .where(Group.FIELD__NAME, "==", Defaults.globalChatName).get()
+
+  if (groupQuery.empty || groupQuery.docs.length > 1) {
+    throw new functions.https.HttpsError('failed-precondition', 'Cannot find global chat.');
+  }
+  const group = groupQuery.docs[0];
+  const chatQuery = await db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Chat.COLLECTION_PATH)
+    .where(Chat.FIELD__GROUP_ID, "==", group.id).get()
+  if (chatQuery.empty || chatQuery.docs.length > 1) {
+    throw new functions.https.HttpsError('failed-precondition', 'Cannot find chatroom associated with group.');
+  }
+
+  await group.ref.update({
+      [Group.FIELD__MEMBERS]: admin.firestore.FieldValue.arrayUnion(player.id)
+  });
+
+  const chatId = chatQuery.docs[0].id;
+  const chatVisibility = {[Player.FIELD__CHAT_VISIBILITY]: true}
+  // We have to use dot-notation or firebase will overwrite the entire field.
+  const membershipField = Player.FIELD__CHAT_MEMBERSHIPS + "." + chatId
+  await player.update({
+    [membershipField]: chatVisibility
+  })
+}
+
+
+// Handles Auto-adding and Auto-removing members
+export async function updateMissionMembership(db: any, gameId: string, groupId: string) {
+  const group = await db.collection(Game.COLLECTION_PATH)
+          .doc(gameId)
+          .collection(Group.COLLECTION_PATH)
+          .doc(groupId)
+          .get()
+  await autoAddMembers(db, gameId, group)
+}
+
+// Adds members if appropriate
+async function autoAddMembers(db: any, gameId: string, group: any) {
+  const groupData = group.data()
+  if (groupData === undefined) {
+    return
+  }
+  if (groupData[Group.FIELD__MANAGED] !== true
+      && groupData[Group.FIELD__SETTINGS][Group.FIELD__SETTINGS_AUTO_ADD] !== true) {
+    return
+  }
+
+  let playerQuerySnapshot = null
+  if (groupData[Group.FIELD__SETTINGS][Group.FIELD__SETTINGS_ALLEGIANCE_FILTER] === Defaults.EMPTY_ALLEGIANCE_FILTER) {
+    // Add all players to the group
+    playerQuerySnapshot = await db.collection(Game.COLLECTION_PATH)
+      .doc(gameId)
+      .collection(Player.COLLECTION_PATH)
+      .get()
+  } else {
+    // Add all players of the correct allegiance to the group
+    playerQuerySnapshot = await db.collection(Game.COLLECTION_PATH)
+      .doc(gameId)
+      .collection(Player.COLLECTION_PATH)
+      .where(Player.FIELD__ALLEGIANCE, "==", groupData[Group.FIELD__SETTINGS][Group.FIELD__SETTINGS_ALLEGIANCE_FILTER])
+      .get()
+  }
+
+  if (playerQuerySnapshot === null) {
+    return
+  }
+  const playerIdArray = new Array();
+  playerQuerySnapshot.forEach((playerDoc: any) => {
+    playerIdArray.push(playerDoc.id)
+  });
+  if (playerIdArray.length > 0) {
+    await group.ref.update({
+        [Group.FIELD__MEMBERS]: playerIdArray
+      })
+  }
+}


### PR DESCRIPTION
- Refactored firebase functions so that group operations are in their own file. This should make future changes easier for updating membership etc
- Disable/enable mission buttons for submitting/updating missions so user can't submit duplicate missions
- Fix ordering of newly created missions so they appear right in the list on the first rendering
- Fix deleting a mission or updating mission allegiance filter to properly stop listening and remove missions from the user's device dynamically so they don't have to change screens and then come back