### PR TITLE
Implement initial version of markdown support

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ConfirmationDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ConfirmationDialog.kt
@@ -32,7 +32,6 @@ class ConfirmationDialog(
     private val descriptionResId: Int? = null,
     private var confirmationResId: Int? = null,
     private var cancelResId: Int? = null
-
 ) : DialogFragment() {
 
     companion object {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/MarkdownInfoDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/MarkdownInfoDialog.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.common
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import androidx.fragment.app.DialogFragment
+import com.app.playhvz.R
+
+class MarkdownInfoDialog() : DialogFragment() {
+
+    companion object {
+        private val TAG = MarkdownInfoDialog::class.qualifiedName
+    }
+
+    private lateinit var customView: View
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        customView = activity!!.layoutInflater.inflate(R.layout.dialog_markdown_info, null)
+
+        val dialog = AlertDialog.Builder(context!!)
+            .setView(customView)
+            .create()
+
+        val negativeButton = customView.findViewById<ImageButton>(R.id.negative_button)
+        negativeButton.setOnClickListener {
+            dialog?.dismiss()
+        }
+        return dialog
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Return already inflated custom view
+        return customView
+    }
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -23,6 +23,7 @@ import android.graphics.Typeface.ITALIC
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
+import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.util.AttributeSet
 import androidx.emoji.widget.EmojiTextView
@@ -31,7 +32,8 @@ class MarkdownView : EmojiTextView {
     companion object {
         enum class TagType {
             BOLD,
-            ITALIC
+            ITALIC,
+            STRIKE_THROUGH
         }
     }
 
@@ -55,7 +57,6 @@ class MarkdownView : EmojiTextView {
         for (tag in TagType.values()) {
             spannable = styleTag(tag, spannable)
         }
-        //spannable = setItalic(spannable)
         super.setText(spannable, BufferType.SPANNABLE)
     }
 
@@ -116,6 +117,7 @@ class MarkdownView : EmojiTextView {
         companion object {
             const val BOLD_REGEX_TAG = "\\*\\*"
             const val ITALIC_REGEX_TAG = "__"
+            const val STRIKE_THROUGH_REGEX_TAG = "~~"
         }
 
         fun getRegex(): String {
@@ -123,23 +125,28 @@ class MarkdownView : EmojiTextView {
                 TagType.BOLD -> {
                     BOLD_REGEX_TAG
                 }
-                else -> {
+                TagType.ITALIC -> {
                     ITALIC_REGEX_TAG
+                }
+                else -> {
+                    STRIKE_THROUGH_REGEX_TAG
                 }
             }
             return "$tagString\\S.*?\\S$tagString"
         }
 
-        fun getSpanStyle(): StyleSpan {
-            val styleType = when (type) {
+        fun getSpanStyle(): Any {
+            return when (type) {
                 TagType.BOLD -> {
-                    BOLD
+                    StyleSpan(BOLD)
+                }
+                TagType.ITALIC -> {
+                    StyleSpan(ITALIC)
                 }
                 else -> {
-                    ITALIC
+                    StrikethroughSpan()
                 }
             }
-            return StyleSpan(styleType)
         }
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.common.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.emoji.widget.EmojiTextView
+
+class MarkdownView : EmojiTextView {
+
+    constructor(context: Context) : this(context, null)
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {}
+
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -17,13 +17,129 @@
 package com.app.playhvz.common.ui
 
 import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface.BOLD
+import android.graphics.Typeface.ITALIC
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
 import android.util.AttributeSet
 import androidx.emoji.widget.EmojiTextView
 
 class MarkdownView : EmojiTextView {
+    companion object {
+        enum class TagType {
+            BOLD,
+            ITALIC
+        }
+    }
 
     constructor(context: Context) : this(context, null)
     constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {}
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    ) {
+    }
 
+    @Override
+    override fun setText(text: CharSequence?, type: BufferType?) {
+        if (text.isNullOrEmpty()) {
+            super.setText(text, type)
+            return
+        }
+        var spannable: SpannableStringBuilder = SpannableStringBuilder(text)
+
+        for (tag in TagType.values()) {
+            spannable = styleTag(tag, spannable)
+        }
+        //spannable = setItalic(spannable)
+        super.setText(spannable, BufferType.SPANNABLE)
+    }
+
+    private fun styleTag(
+        tagType: TagType,
+        spannable: SpannableStringBuilder
+    ): SpannableStringBuilder {
+        val tag = Tag(tagType)
+        var startIndex = 0
+        val regex: Regex = Regex(tag.getRegex())
+
+        while (startIndex < spannable.length) {
+            val result = regex.find(spannable, startIndex)
+            if (result != null) {
+                startIndex = Math.min(result.range.last + 1, spannable.length)
+                var startTagStartInclusive = result.range.first
+                if (spannable[startTagStartInclusive].isWhitespace()) {
+                    // The starting space or ending space is counted in the result range, skip it
+                    startTagStartInclusive++
+                }
+                val startTagEndExclusive = startTagStartInclusive + 2
+                var endTagEndExclusive = Math.min(result.range.last + 1, spannable.length)
+                if (spannable[endTagEndExclusive - 1].isWhitespace()) {
+                    endTagEndExclusive--
+                }
+                val endTagStartInclusive = endTagEndExclusive - 2
+                // Contrary to what you'd think, the spannable inclusive/exclusive tag has nothing
+                // to do with the start and end index you supply, it only matters for whether text
+                // inserted in those spots will be styled... the start and end indexes should always
+                // be inclusive,exclusive no matter what the tag you use says.
+                spannable.setSpan(
+                    ForegroundColorSpan(Color.TRANSPARENT),
+                    startTagStartInclusive,
+                    startTagEndExclusive,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                spannable.setSpan(
+                    tag.getSpanStyle(),
+                    startTagEndExclusive,
+                    endTagStartInclusive,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                spannable.setSpan(
+                    ForegroundColorSpan(Color.TRANSPARENT),
+                    endTagStartInclusive,
+                    endTagEndExclusive,
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+            } else {
+                startIndex = spannable.length + 1
+            }
+        }
+        return spannable
+    }
+
+
+    class Tag(val type: TagType) {
+        companion object {
+            const val BOLD_REGEX_TAG = "\\*\\*"
+            const val ITALIC_REGEX_TAG = "__"
+        }
+
+        fun getRegex(): String {
+            val tagString = when (type) {
+                TagType.BOLD -> {
+                    BOLD_REGEX_TAG
+                }
+                else -> {
+                    ITALIC_REGEX_TAG
+                }
+            }
+            return "$tagString\\S.*?\\S$tagString"
+        }
+
+        fun getSpanStyle(): StyleSpan {
+            val styleType = when (type) {
+                TagType.BOLD -> {
+                    BOLD
+                }
+                else -> {
+                    ITALIC
+                }
+            }
+            return StyleSpan(styleType)
+        }
+    }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/gamedashboard/cards/MissionCard.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/gamedashboard/cards/MissionCard.kt
@@ -23,6 +23,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.emoji.widget.EmojiTextView
 import androidx.navigation.NavController
 import com.app.playhvz.R
+import com.app.playhvz.common.ui.MarkdownView
 import com.app.playhvz.firebase.classmodels.Mission
 import com.app.playhvz.navigation.NavigationUtil
 import com.app.playhvz.screens.gamedashboard.GameDashboardFragment
@@ -41,7 +42,7 @@ class MissionCard(
     lateinit var cardTitle: EmojiTextView
     lateinit var startTimeView: TextView
     lateinit var endTimeView: TextView
-    lateinit var detailsView: EmojiTextView
+    lateinit var detailsView: MarkdownView
     lateinit var cardHeader: LinearLayout
     lateinit var cardHeaderIcon: MaterialButton
     lateinit var cardContent: ConstraintLayout

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
@@ -18,6 +18,7 @@ package com.app.playhvz.screens.missions.missionsettings
 
 import android.os.Bundle
 import android.view.*
+import android.widget.ImageButton
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -30,6 +31,7 @@ import com.app.playhvz.R
 import com.app.playhvz.app.EspressoIdlingResource
 import com.app.playhvz.common.ConfirmationDialog
 import com.app.playhvz.common.DateTimePickerDialog
+import com.app.playhvz.common.MarkdownInfoDialog
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.BLANK_ALLEGIANCE_FILTER
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.HUMAN
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.UNDECLARED
@@ -98,7 +100,11 @@ class MissionSettingsFragment : Fragment() {
         submitButton = view.findViewById(R.id.submit_button)
         startTime = view.findViewById(R.id.mission_start_time)
         endTime = view.findViewById(R.id.mission_end_time)
-        allegianceRadioGroup = view!!.findViewById(R.id.radio_button_group)
+        allegianceRadioGroup = view.findViewById(R.id.radio_button_group)
+        val markdownInfoButton = view.findViewById<ImageButton>(R.id.markdown_info_button)
+        markdownInfoButton.setOnClickListener {
+            activity?.supportFragmentManager?.let { MarkdownInfoDialog().show(it, TAG) }
+        }
 
         submitButton.setOnClickListener {
             submitMission()

--- a/Android/ghvzApp/app/src/main/res/drawable/ic_x.xml
+++ b/Android/ghvzApp/app/src/main/res/drawable/ic_x.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12 19,6.41z"/>
+</vector>

--- a/Android/ghvzApp/app/src/main/res/layout/card_mission.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/card_mission.xml
@@ -94,9 +94,9 @@
         app:layout_constraintTop_toTopOf="@id/mission_start_time"
         tools:text="Jun 06\n4:00 PM" />
 
-      <androidx.emoji.widget.EmojiTextView
+      <com.app.playhvz.common.ui.MarkdownView
         android:id="@+id/mission_details"
-        style="@style/TextAppearance.AppCompat.Body2"
+        style="@style/TextAppearance.MaterialComponents.Body2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="20dp"

--- a/Android/ghvzApp/app/src/main/res/layout/dialog_markdown_info.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/dialog_markdown_info.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="wrap_content"
+  android:layout_height="wrap_content"
+  android:minWidth="@dimen/app_minimum_dialog_width"
+  android:minHeight="@dimen/app_minimum_dialog_height"
+  android:orientation="vertical"
+  android:padding="6dp">
+
+  <ImageButton
+    android:id="@+id/negative_button"
+    style="@style/ImageButtonStyle"
+    android:src="@drawable/ic_x"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
+  <TextView
+    android:id="@+id/bold_raw"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_bold_raw"
+    android:textSize="18sp"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/negative_button"
+    tools:ignore="RtlSymmetry" />
+
+  <com.app.playhvz.common.ui.MarkdownView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="4dp"
+    android:paddingEnd="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_bold_display"
+    android:textSize="18sp"
+    app:layout_constraintStart_toEndOf="@id/bold_raw"
+    app:layout_constraintTop_toTopOf="@id/bold_raw"
+    tools:ignore="RtlSymmetry" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/ghvzApp/app/src/main/res/layout/dialog_markdown_info.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/dialog_markdown_info.xml
@@ -53,5 +53,49 @@
     app:layout_constraintTop_toTopOf="@id/bold_raw"
     tools:ignore="RtlSymmetry" />
 
+  <TextView
+    android:id="@+id/italic_raw"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_italic_raw"
+    android:textSize="18sp"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/bold_raw"
+    tools:ignore="RtlSymmetry" />
+
+  <com.app.playhvz.common.ui.MarkdownView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="4dp"
+    android:paddingEnd="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_italic_display"
+    android:textSize="18sp"
+    app:layout_constraintStart_toEndOf="@id/italic_raw"
+    app:layout_constraintTop_toTopOf="@id/italic_raw"
+    tools:ignore="RtlSymmetry" />
+
+  <TextView
+    android:id="@+id/strike_raw"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_strike_raw"
+    android:textSize="18sp"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/italic_raw"
+    tools:ignore="RtlSymmetry" />
+
+  <com.app.playhvz.common.ui.MarkdownView
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="4dp"
+    android:paddingEnd="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_strike_display"
+    android:textSize="18sp"
+    app:layout_constraintStart_toEndOf="@id/strike_raw"
+    app:layout_constraintTop_toTopOf="@id/strike_raw"
+    tools:ignore="RtlSymmetry" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
@@ -15,6 +15,7 @@
   -->
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -136,20 +137,36 @@
         android:text="@string/allegiance_option_everyone" />
     </RadioGroup>
 
-    <TextView
-      style="@style/TextInputLabel"
+
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:text="@string/mission_settings_details_label" />
+      android:layout_height="wrap_content">
+
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/mission_settings_details_label"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="@id/markdown_info_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/markdown_info_button" />
+
+      <ImageButton
+        android:id="@+id/markdown_info_button"
+        style="@style/ImageButtonStyle"
+        android:contentDescription="@string/markdown_dialog_trigger_content_description"
+        android:src="@drawable/ic_info"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.emoji.widget.EmojiEditText
       android:id="@+id/mission_details"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="top"
-      android:layout_marginTop="16dp"
       android:background="@drawable/rectangular_border"
-      android:gravity="left|top"
+      android:gravity="start|top"
       android:lines="12" />
 
     <Button

--- a/Android/ghvzApp/app/src/main/res/values/colors.xml
+++ b/Android/ghvzApp/app/src/main/res/values/colors.xml
@@ -30,6 +30,7 @@
   <color name="app_primary_text">@color/grey800</color>
   <color name="app_secondary_text">@color/grey700</color>
   <color name="sublabel_text">@color/grey500</color>
+  <color name="secondary_icon_button">@color/grey500</color>
 
   <color name="divider">#1F000000</color> <!-- 12% opacity grey -->
 </resources>

--- a/Android/ghvzApp/app/src/main/res/values/dimens.xml
+++ b/Android/ghvzApp/app/src/main/res/values/dimens.xml
@@ -24,6 +24,7 @@
   <dimen name="divider_height">1dp</dimen>
   <dimen name="horizontal_progress_bar_height">10dp</dimen>
   <dimen name="screen_margin_horizontal">16dp</dimen>
+  <dimen name="tap_target_min">48dp</dimen>
 
   <dimen name="avatar_small">32dp</dimen>
   <dimen name="avatar_large">56dp</dimen>

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -74,6 +74,10 @@
     Create
   </string>
 
+  <string name="button_dismiss" definition="Dismiss button.">
+    Dismiss
+  </string>
+
   <string name="button_next" definition="Button to select when saving changes and going to the next screen.">
     Next
   </string>
@@ -287,6 +291,14 @@
     For past life codes see your profile page.
   </string>
 
+  <string name="markdown_hint_bold_raw" definition="Raw text hint for bold markdown text.">
+    **Text** →
+  </string>
+
+  <string name="markdown_hint_bold_display" definition="Actual styled text for bold markdown text.">
+    **Text**
+  </string>
+
   <string name="menu_bottom_nav_chat" definition="Bottom navigation menu item for opening chat.">
     Chat
   </string>
@@ -410,6 +422,10 @@
 
   <string name="force_upgrade_image_content_description" definition="Content description for force upgrade image.">
     poo
+  </string>
+
+  <string name="markdown_dialog_trigger_content_description" definition="Content description for the button that opens the markdown cheatsheet.">
+    View Markdown hints
   </string>
 
   <!-- Non-translatable strings -->

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -299,6 +299,22 @@
     **Text**
   </string>
 
+  <string name="markdown_hint_italic_raw" definition="Raw text hint for italic markdown text.">
+    __Text__ →
+  </string>
+
+  <string name="markdown_hint_italic_display" definition="Actual styled text for italic markdown text.">
+    __Text__
+  </string>
+
+  <string name="markdown_hint_strike_raw" definition="Raw text hint for strike through markdown text.">
+    ~~Text~~ →
+  </string>
+
+  <string name="markdown_hint_strike_display" definition="Actual styled text for strike through markdown text.">
+    ~~Text~~
+  </string>
+
   <string name="menu_bottom_nav_chat" definition="Bottom navigation menu item for opening chat.">
     Chat
   </string>

--- a/Android/ghvzApp/app/src/main/res/values/styles.xml
+++ b/Android/ghvzApp/app/src/main/res/values/styles.xml
@@ -73,4 +73,11 @@
     <item name="android:textAllCaps">true</item>
   </style>
 
+  <style name="ImageButtonStyle">
+    <item name="android:layout_width">@dimen/tap_target_min</item>
+    <item name="android:layout_height">@dimen/tap_target_min</item>
+    <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
+    <item name="android:tint">@color/secondary_icon_button</item>
+  </style>
+
 </resources>


### PR DESCRIPTION
Implements initial version of markdown support. Only really supports ** for bold, __ for italics, and ~~ for strikethrough. Headers almost work but there's a bug I just figured out while typing this commit message, brb