### PR TITLE
Finish up simple markdown text formating support

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/MarkdownInfoDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/MarkdownInfoDialog.kt
@@ -18,24 +18,46 @@ package com.app.playhvz.common
 
 import android.app.AlertDialog
 import android.app.Dialog
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.TextView
 import androidx.fragment.app.DialogFragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.app.playhvz.R
+import com.app.playhvz.common.ui.MarkdownView
 
 class MarkdownInfoDialog() : DialogFragment() {
-
     companion object {
         private val TAG = MarkdownInfoDialog::class.qualifiedName
     }
+
+    private val HELP_STRING_IDS = listOf(
+        R.string.markdown_hint_bold,
+        R.string.markdown_hint_italic,
+        R.string.markdown_hint_strike,
+        R.string.markdown_hint_heading1,
+        R.string.markdown_hint_heading2,
+        R.string.markdown_hint_heading3,
+        R.string.markdown_hint_heading4,
+        R.string.markdown_hint_heading5,
+        R.string.markdown_hint_heading6
+    )
 
     private lateinit var customView: View
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         customView = activity!!.layoutInflater.inflate(R.layout.dialog_markdown_info, null)
+        val recyclerView = customView.findViewById<RecyclerView>(R.id.markdown_example_list)
+        val adapter = HelpItemAdapter(context!!)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        recyclerView.adapter = adapter
+        adapter.setResIds(HELP_STRING_IDS)
+        adapter.notifyDataSetChanged()
 
         val dialog = AlertDialog.Builder(context!!)
             .setView(customView)
@@ -54,5 +76,40 @@ class MarkdownInfoDialog() : DialogFragment() {
     ): View? {
         // Return already inflated custom view
         return customView
+    }
+
+    class HelpItemAdapter(val context: Context) :
+        RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+        var data: List<Int> = listOf()
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+            return HelpItemViewHolder(
+                LayoutInflater.from(context).inflate(
+                    R.layout.list_item_markdown_example,
+                    parent,
+                    false
+                )
+            )
+        }
+
+        override fun getItemCount(): Int {
+            return data.size
+        }
+
+        override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+            (holder as HelpItemViewHolder).onBind(context.getString(data[position]))
+        }
+
+        fun setResIds(resIds: List<Int>) {
+            data = resIds
+        }
+    }
+
+    class HelpItemViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
+        private val exampleText = view.findViewById<TextView>(R.id.example_text)
+        private val displayText = view.findViewById<MarkdownView>(R.id.display_text)
+        fun onBind(markdownString: String) {
+            exampleText.text = markdownString
+            displayText.text = markdownString
+        }
     }
 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/HiddenSpan.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/HiddenSpan.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.common.ui
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.text.style.ReplacementSpan
+
+/** This is a span that hides text from display but doesn't remove the underlying text from the string. */
+class HiddenSpan() : ReplacementSpan() {
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        fm: Paint.FontMetricsInt?
+    ): Int {
+        // We don't want this span to be visible so paint size should be 0 pixels.
+        return 0
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
+        // Nothing should be drawn... so do nothing :^D
+    }
+
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -107,7 +107,7 @@ class MarkdownView : EmojiTextView {
                     return HEADING_REGEX_TAG
                 }
             }
-            return "$tagString\\S.*?\\S$tagString"
+            return "$tagString\\S*?\\S$tagString"
         }
 
         fun getSpanStyle(relativeSize: Float = 1f): Any {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -17,12 +17,10 @@
 package com.app.playhvz.common.ui
 
 import android.content.Context
-import android.graphics.Color
 import android.graphics.Typeface.BOLD
 import android.graphics.Typeface.ITALIC
 import android.text.Spannable
 import android.text.SpannableStringBuilder
-import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
@@ -157,7 +155,7 @@ class MarkdownView : EmojiTextView {
             // inserted in those spots will be styled... the start and end indexes should always
             // be inclusive,exclusive no matter what the tag you use says.
             spannable.setSpan(
-                ForegroundColorSpan(Color.TRANSPARENT),
+                HiddenSpan(),
                 startTagStartInclusive,
                 startTagEndExclusive,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
@@ -169,7 +167,7 @@ class MarkdownView : EmojiTextView {
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
             )
             spannable.setSpan(
-                ForegroundColorSpan(Color.TRANSPARENT),
+                HiddenSpan(),
                 endTagStartInclusive,
                 endTagEndExclusive,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
@@ -183,7 +181,15 @@ class MarkdownView : EmojiTextView {
         ): SpannableStringBuilder {
             val numberOfHashtagsInclusive = regexMatch.groupValues[2].length
             val startTagStartInclusive = regexMatch.range.first
-            val startTagEndExclusive = startTagStartInclusive + numberOfHashtagsInclusive + 1
+            // +1 because we need this to be exclusive not inclusive
+            var startTagEndExclusive = startTagStartInclusive + numberOfHashtagsInclusive + 1
+            if (spannable[startTagEndExclusive].isWhitespace()) {
+                // Make sure to include the space after the "#" as part of the header tag. For some
+                // reason I don't really care enough to figure out, the space isn't counted if there
+                // was a newline before the heading tag, but it is already counted if we were at the
+                // start of the string (\n vs ^ in regex).
+                startTagEndExclusive++
+            }
             var endOfContentExclusive = Math.min(regexMatch.range.last + 1, spannable.length)
             if (spannable[endOfContentExclusive - 1].isWhitespace()) {
                 endOfContentExclusive--
@@ -197,7 +203,7 @@ class MarkdownView : EmojiTextView {
             // inserted in those spots will be styled... the start and end indexes should always
             // be inclusive,exclusive no matter what the tag you use says.
             spannable.setSpan(
-                ForegroundColorSpan(Color.TRANSPARENT),
+                HiddenSpan(),
                 startTagStartInclusive,
                 startTagEndExclusive,
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -89,7 +89,7 @@ class MarkdownView : EmojiTextView {
             const val BOLD_REGEX_TAG = "\\*\\*"
             const val ITALIC_REGEX_TAG = "__"
             const val STRIKE_THROUGH_REGEX_TAG = "~~"
-            const val HEADING_REGEX_TAG = "(^|\\s)(#{1,6})\\s.*?\\n"
+            const val HEADING_REGEX_TAG = "(^|\\s)(#{1,6})(\\s.*?)?\\n"
         }
 
         fun getRegex(): String {
@@ -107,7 +107,7 @@ class MarkdownView : EmojiTextView {
                     return HEADING_REGEX_TAG
                 }
             }
-            return "$tagString\\S*?\\S$tagString"
+            return "$tagString(\\S.*?)?\\S$tagString"
         }
 
         fun getSpanStyle(relativeSize: Float = 1f): Any {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownView.kt
@@ -89,7 +89,7 @@ class MarkdownView : EmojiTextView {
             const val BOLD_REGEX_TAG = "\\*\\*"
             const val ITALIC_REGEX_TAG = "__"
             const val STRIKE_THROUGH_REGEX_TAG = "~~"
-            const val HEADING_REGEX_TAG = "(^|\\s)(#{1,6})(\\s.*?)?\\n"
+            const val HEADING_REGEX_TAG = "(^|\\s)(#{1,6})(\\s.*?)?(\\n|$)"
         }
 
         fun getRegex(): String {

--- a/Android/ghvzApp/app/src/main/res/layout/dialog_markdown_info.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/dialog_markdown_info.xml
@@ -16,86 +16,41 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
   android:minWidth="@dimen/app_minimum_dialog_width"
   android:minHeight="@dimen/app_minimum_dialog_height"
   android:orientation="vertical"
-  android:padding="6dp">
+  android:padding="6dp"
+  android:paddingBottom="@dimen/screen_margin_horizontal">
+
+  <TextView
+    style="@style/TextAppearance.MaterialComponents.Headline6"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/screen_margin_horizontal"
+    android:paddingEnd="@dimen/screen_margin_horizontal"
+    android:text="@string/markdown_hint_dialog_title"
+    android:textColor="@color/app_secondary_text"
+    app:layout_constraintBottom_toBottomOf="@id/negative_button"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="@id/negative_button" />
 
   <ImageButton
     android:id="@+id/negative_button"
     style="@style/ImageButtonStyle"
+    android:contentDescription="@string/button_dismiss"
     android:src="@drawable/ic_x"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
-  <TextView
-    android:id="@+id/bold_raw"
-    android:layout_width="wrap_content"
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/markdown_example_list"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="@dimen/screen_margin_horizontal"
-    android:text="@string/markdown_hint_bold_raw"
-    android:textSize="18sp"
+    android:paddingTop="8dp"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/negative_button"
-    tools:ignore="RtlSymmetry" />
-
-  <com.app.playhvz.common.ui.MarkdownView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingStart="4dp"
-    android:paddingEnd="@dimen/screen_margin_horizontal"
-    android:text="@string/markdown_hint_bold_display"
-    android:textSize="18sp"
-    app:layout_constraintStart_toEndOf="@id/bold_raw"
-    app:layout_constraintTop_toTopOf="@id/bold_raw"
-    tools:ignore="RtlSymmetry" />
-
-  <TextView
-    android:id="@+id/italic_raw"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingStart="@dimen/screen_margin_horizontal"
-    android:text="@string/markdown_hint_italic_raw"
-    android:textSize="18sp"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/bold_raw"
-    tools:ignore="RtlSymmetry" />
-
-  <com.app.playhvz.common.ui.MarkdownView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingStart="4dp"
-    android:paddingEnd="@dimen/screen_margin_horizontal"
-    android:text="@string/markdown_hint_italic_display"
-    android:textSize="18sp"
-    app:layout_constraintStart_toEndOf="@id/italic_raw"
-    app:layout_constraintTop_toTopOf="@id/italic_raw"
-    tools:ignore="RtlSymmetry" />
-
-  <TextView
-    android:id="@+id/strike_raw"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingStart="@dimen/screen_margin_horizontal"
-    android:text="@string/markdown_hint_strike_raw"
-    android:textSize="18sp"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/italic_raw"
-    tools:ignore="RtlSymmetry" />
-
-  <com.app.playhvz.common.ui.MarkdownView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingStart="4dp"
-    android:paddingEnd="@dimen/screen_margin_horizontal"
-    android:text="@string/markdown_hint_strike_display"
-    android:textSize="18sp"
-    app:layout_constraintStart_toEndOf="@id/strike_raw"
-    app:layout_constraintTop_toTopOf="@id/strike_raw"
-    tools:ignore="RtlSymmetry" />
-
+    app:layout_constraintTop_toBottomOf="@id/negative_button" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/ghvzApp/app/src/main/res/layout/list_item_markdown_example.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/list_item_markdown_example.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:paddingStart="6dp"
+  android:paddingEnd="6dp">
+
+  <TextView
+    android:id="@+id/example_text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textSize="18sp"
+    app:layout_constraintBottom_toBottomOf="@id/display_text"
+    app:layout_constraintEnd_toStartOf="@id/arrow"
+    app:layout_constraintTop_toTopOf="@id/display_text" />
+
+  <TextView
+    android:id="@+id/arrow"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="6dp"
+    android:paddingEnd="6dp"
+    android:text="@string/markdown_hint_arrow"
+    android:textSize="18sp"
+    app:layout_constraintBottom_toBottomOf="@id/display_text"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="@id/display_text" />
+
+  <com.app.playhvz.common.ui.MarkdownView
+    android:id="@+id/display_text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textSize="18sp"
+    app:layout_constraintStart_toEndOf="@id/arrow"
+    app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -291,28 +291,48 @@
     For past life codes see your profile page.
   </string>
 
-  <string name="markdown_hint_bold_raw" definition="Raw text hint for bold markdown text.">
-    **Text** →
+  <string name="markdown_hint_dialog_title" definition="Dialog title for showing markdown hints.">
+    Markdown hints
   </string>
 
-  <string name="markdown_hint_bold_display" definition="Actual styled text for bold markdown text.">
-    **Text**
+  <string name="markdown_hint_arrow" definition="Arrow demonstrating left is relevant to right.">
+    →
   </string>
 
-  <string name="markdown_hint_italic_raw" definition="Raw text hint for italic markdown text.">
-    __Text__ →
+  <string name="markdown_hint_bold" definition="Text for bold markdown text.">
+    **bold**
   </string>
 
-  <string name="markdown_hint_italic_display" definition="Actual styled text for italic markdown text.">
-    __Text__
+  <string name="markdown_hint_italic" definition="Text for italic markdown text.">
+    __italic__
   </string>
 
-  <string name="markdown_hint_strike_raw" definition="Raw text hint for strike through markdown text.">
-    ~~Text~~ →
+  <string name="markdown_hint_strike" definition="Text for strikethrough markdown text.">
+    ~~strikethrough~~
   </string>
 
-  <string name="markdown_hint_strike_display" definition="Actual styled text for strike through markdown text.">
-    ~~Text~~
+  <string name="markdown_hint_heading1" definition="Text for heading1 markdown text.">
+    # H1
+  </string>
+
+  <string name="markdown_hint_heading2" definition="Text for heading2 markdown text.">
+    ## H2
+  </string>
+
+  <string name="markdown_hint_heading3" definition="Text for heading3 markdown text.">
+    ### H3
+  </string>
+
+  <string name="markdown_hint_heading4" definition="Text for heading4 markdown text.">
+    #### H4
+  </string>
+
+  <string name="markdown_hint_heading5" definition="Text for heading5 markdown text.">
+    ##### H5
+  </string>
+
+  <string name="markdown_hint_heading6" definition="Text for heading6 markdown text.">
+    ###### H6
   </string>
 
   <string name="menu_bottom_nav_chat" definition="Bottom navigation menu item for opening chat.">

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -307,8 +307,8 @@
     __italic__
   </string>
 
-  <string name="markdown_hint_strike" definition="Text for strikethrough markdown text.">
-    ~~strikethrough~~
+  <string name="markdown_hint_strike" definition="Text for strike-through markdown text.">
+    ~~strike~~
   </string>
 
   <string name="markdown_hint_heading1" definition="Text for heading1 markdown text.">


### PR DESCRIPTION
Finishes the basic markdown implementation we plan to support. Namely headings, bold, strike, and italic text. Also polished up the help dialog that demonstrates each format.