### PR TITLE
Delete rules/faq, inline markdown hint dialog

### DIFF
--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ConfirmationDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ConfirmationDialog.kt
@@ -43,7 +43,7 @@ class ConfirmationDialog(
     var onCancel: (() -> Unit)? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        customView = activity!!.layoutInflater.inflate(R.layout.dialog_confirmation, null)
+        customView = requireActivity().layoutInflater.inflate(R.layout.dialog_confirmation, null)
         val descriptionTextView = customView.findViewById<TextView>(R.id.dialog_description)
 
         if (descriptionResId == null) {
@@ -59,7 +59,7 @@ class ConfirmationDialog(
             cancelResId = R.string.button_cancel
         }
 
-        val dialog = AlertDialog.Builder(context!!)
+        val dialog = AlertDialog.Builder(requireContext())
             .setTitle(title)
             .setView(customView)
             .create()

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/MarkdownInfoDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/MarkdownInfoDialog.kt
@@ -29,7 +29,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.app.playhvz.R
-import com.app.playhvz.common.ui.MarkdownView
+import com.app.playhvz.common.ui.MarkdownTextView
 
 class MarkdownInfoDialog() : DialogFragment() {
     companion object {
@@ -106,7 +106,7 @@ class MarkdownInfoDialog() : DialogFragment() {
 
     class HelpItemViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
         private val exampleText = view.findViewById<TextView>(R.id.example_text)
-        private val displayText = view.findViewById<MarkdownView>(R.id.display_text)
+        private val displayText = view.findViewById<MarkdownTextView>(R.id.display_text)
         fun onBind(markdownString: String) {
             exampleText.text = markdownString
             displayText.text = markdownString

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownEditView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownEditView.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.common.ui
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.core.content.ContextCompat
+import androidx.emoji.widget.EmojiEditText
+import androidx.fragment.app.FragmentActivity
+import com.app.playhvz.R
+import com.app.playhvz.common.MarkdownInfoDialog
+
+/** An edit text that has an information button build in that shows the markdown hint dialog. */
+class MarkdownEditText(
+    context: Context?,
+    attrs: AttributeSet?
+) : EmojiEditText(context, attrs) {
+    companion object {
+        private val TAG = MarkdownEditText::class.qualifiedName
+    }
+
+    // Left = 0, Top = 1, Right = 2, Bottom = 3
+    private val RIGHT = 2
+    private var rect = Rect()
+
+    init {
+        val infoIcon = ContextCompat.getDrawable(context!!, R.drawable.ic_info)!!
+        infoIcon.mutate().setTint(ContextCompat.getColor(context, R.color.secondary_icon_button))
+        setCompoundDrawablesWithIntrinsicBounds(
+            null,
+            null,
+            infoIcon,
+            null
+        )
+        compoundDrawablePadding =
+            context.resources.getDimensionPixelSize(R.dimen.markdown_icon_padding)
+
+        setOnTouchListener { v, event ->
+            val view = v as MarkdownEditText
+            if (event.action == MotionEvent.ACTION_UP) {
+                if (event.rawX >= (view.right - view.compoundDrawables[RIGHT].bounds.width())) {
+                    showMarkdownHintDialog()
+                    return@setOnTouchListener true
+                }
+            }
+            return@setOnTouchListener false
+        }
+    }
+
+    /**
+     * Forces the drawable to appear at the top right corner of the view.
+     */
+    override fun dispatchDraw(canvas: Canvas?) {
+        super.dispatchDraw(canvas)
+        val centerOfTextView = height / 2
+        getLineBounds(0, rect)
+        val heightOfTextLine: Int = rect.bottom - rect.top
+        val centerOfLine = heightOfTextLine / 2
+        val topOfDrawable = centerOfLine - centerOfTextView
+        val compoundDrawables = compoundDrawables
+        val drawableRight = compoundDrawables[RIGHT]
+        val padding = compoundDrawablePadding / 2
+        drawableRight?.setBounds(
+            0 - padding,
+            topOfDrawable + padding,
+            drawableRight.intrinsicWidth - padding,
+            drawableRight.intrinsicHeight + topOfDrawable + padding
+        )
+    }
+
+    private fun showMarkdownHintDialog() {
+        getActivity()!!.supportFragmentManager.let { MarkdownInfoDialog().show(it, TAG) }
+    }
+
+    private fun getActivity(): FragmentActivity? {
+        var context = context
+        while (context is ContextWrapper) {
+            if (context is FragmentActivity) {
+                return context
+            }
+            context = context.baseContext
+        }
+        return null
+    }
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownTextView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownTextView.kt
@@ -196,7 +196,7 @@ class MarkdownTextView : EmojiTextView {
             }
 
             // The more #, the smaller the heading.
-            val textSizeMultiplier = (4 - (0.35f * numberOfHashtagsInclusive))
+            val textSizeMultiplier = (3.2f - (0.35f * numberOfHashtagsInclusive))
 
             // Contrary to what you'd think, the spannable inclusive/exclusive tag has nothing
             // to do with the start and end index you supply, it only matters for whether text

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownTextView.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/ui/MarkdownTextView.kt
@@ -27,7 +27,7 @@ import android.text.style.StyleSpan
 import android.util.AttributeSet
 import androidx.emoji.widget.EmojiTextView
 
-class MarkdownView : EmojiTextView {
+class MarkdownTextView : EmojiTextView {
     companion object {
         enum class TagType {
             BOLD,

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/gamedashboard/cards/MissionCard.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/gamedashboard/cards/MissionCard.kt
@@ -23,7 +23,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.emoji.widget.EmojiTextView
 import androidx.navigation.NavController
 import com.app.playhvz.R
-import com.app.playhvz.common.ui.MarkdownView
+import com.app.playhvz.common.ui.MarkdownTextView
 import com.app.playhvz.firebase.classmodels.Mission
 import com.app.playhvz.navigation.NavigationUtil
 import com.app.playhvz.screens.gamedashboard.GameDashboardFragment
@@ -42,7 +42,7 @@ class MissionCard(
     lateinit var cardTitle: EmojiTextView
     lateinit var startTimeView: TextView
     lateinit var endTimeView: TextView
-    lateinit var detailsView: MarkdownView
+    lateinit var detailsView: MarkdownTextView
     lateinit var cardHeader: LinearLayout
     lateinit var cardHeaderIcon: MaterialButton
     lateinit var cardContent: ConstraintLayout

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/missions/missionsettings/MissionSettingsFragment.kt
@@ -18,7 +18,6 @@ package com.app.playhvz.screens.missions.missionsettings
 
 import android.os.Bundle
 import android.view.*
-import android.widget.ImageButton
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -31,7 +30,6 @@ import com.app.playhvz.R
 import com.app.playhvz.app.EspressoIdlingResource
 import com.app.playhvz.common.ConfirmationDialog
 import com.app.playhvz.common.DateTimePickerDialog
-import com.app.playhvz.common.MarkdownInfoDialog
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.BLANK_ALLEGIANCE_FILTER
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.HUMAN
 import com.app.playhvz.common.globals.CrossClientConstants.Companion.UNDECLARED
@@ -101,10 +99,6 @@ class MissionSettingsFragment : Fragment() {
         startTime = view.findViewById(R.id.mission_start_time)
         endTime = view.findViewById(R.id.mission_end_time)
         allegianceRadioGroup = view.findViewById(R.id.radio_button_group)
-        val markdownInfoButton = view.findViewById<ImageButton>(R.id.markdown_info_button)
-        markdownInfoButton.setOnClickListener {
-            activity?.supportFragmentManager?.let { MarkdownInfoDialog().show(it, TAG) }
-        }
 
         submitButton.setOnClickListener {
             submitMission()
@@ -130,15 +124,21 @@ class MissionSettingsFragment : Fragment() {
         return view
     }
 
+    override fun onDestroyView() {
+        SystemUtils.hideKeyboard(requireContext())
+        super.onDestroyView()
+    }
+
     fun setupToolbar() {
         val toolbar = (activity as AppCompatActivity).supportActionBar
         setHasOptionsMenu(true)
         if (toolbar != null) {
             if (missionId == null) {
-                toolbar.title = context!!.getString(R.string.mission_settings_create_mission_title)
+                toolbar.title =
+                    requireContext().getString(R.string.mission_settings_create_mission_title)
                 return
             }
-            toolbar.title = context!!.getString(R.string.mission_settings_title)
+            toolbar.title = requireContext().getString(R.string.mission_settings_title)
         }
     }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/CollapsibleListFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/CollapsibleListFragment.kt
@@ -30,6 +30,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.app.playhvz.R
 import com.app.playhvz.app.EspressoIdlingResource
+import com.app.playhvz.common.ConfirmationDialog
 import com.app.playhvz.common.globals.SharedPreferencesConstants
 import com.app.playhvz.firebase.classmodels.Game
 import com.app.playhvz.firebase.operations.GameDatabaseOperations
@@ -41,6 +42,10 @@ import kotlinx.coroutines.runBlocking
 
 
 class CollapsibleListFragment : Fragment() {
+    companion object {
+        private val TAG = CollapsibleListFragment::class.qualifiedName
+    }
+
     enum class CollapsibleFragmentType {
         RULES,
         FAQ
@@ -228,15 +233,29 @@ class CollapsibleListFragment : Fragment() {
         }
         if (isAdmin) {
             fab.visibility = View.VISIBLE
-            val onRuleAdded = {
-                val newRule = Game.CollapsibleSection()
-                newRule.order = currentCollapsibleSections.size
-                currentCollapsibleSections.add(newRule)
+            val onSectionAdded = {
+                val newSection = Game.CollapsibleSection()
+                newSection.order = currentCollapsibleSections.size
+                currentCollapsibleSections.add(newSection)
                 editAdapter?.setData(currentCollapsibleSections)
                 editAdapter?.notifyDataSetChanged()
             }
+            val onSectionDeleted = { position: Int ->
+                val confirmationDialog = ConfirmationDialog(
+                    getString(R.string.collapsible_section_remove_dialog_title),
+                    R.string.collapsible_section_remove_dialog_content,
+                    R.string.delete_button_content_description
+                )
+                confirmationDialog.setPositiveButtonCallback {
+                    currentCollapsibleSections.removeAt(position)
+                    editAdapter?.setData(currentCollapsibleSections)
+                    editAdapter?.notifyDataSetChanged()
+                }
+                activity?.supportFragmentManager?.let { confirmationDialog.show(it, TAG) }
+            }
             if (editAdapter == null) {
-                editAdapter = EditCollapsibleSectionAdapter(listOf(), this, onRuleAdded)
+                editAdapter =
+                    EditCollapsibleSectionAdapter(listOf(), this, onSectionAdded, onSectionDeleted)
 
             }
         } else if (fab.visibility == View.VISIBLE) {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/DisplayCollapsibleSectionViewHolder.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/DisplayCollapsibleSectionViewHolder.kt
@@ -20,13 +20,13 @@ import android.view.View
 import androidx.emoji.widget.EmojiTextView
 import androidx.recyclerview.widget.RecyclerView
 import com.app.playhvz.R
-import com.app.playhvz.common.ui.MarkdownView
+import com.app.playhvz.common.ui.MarkdownTextView
 import com.app.playhvz.firebase.classmodels.Game
 
 class DisplayCollapsibleSectionViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
 
     private val sectionTitle = view.findViewById<EmojiTextView>(R.id.section_title)!!
-    private val sectionContent = view.findViewById<MarkdownView>(R.id.section_content)!!
+    private val sectionContent = view.findViewById<MarkdownTextView>(R.id.section_content)!!
 
     fun onBind(section: Game.CollapsibleSection) {
         sectionTitle.text = section.sectionTitle

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/EditCollapsibleSectionAdapter.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/EditCollapsibleSectionAdapter.kt
@@ -69,11 +69,6 @@ class EditCollapsibleSectionAdapter(
             parent,
             false
         )
-        val markdownInfoButton =
-            editableSectionLayout.findViewById<ImageButton>(R.id.markdown_info_button)
-        markdownInfoButton.setOnClickListener {
-            fragment.activity?.supportFragmentManager?.let { MarkdownInfoDialog().show(it, TAG) }
-        }
         return EditCollapsibleSectionViewHolder(
             LayoutInflater.from(fragment.context).inflate(
                 R.layout.list_item_collapsible_section_edit,

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/EditCollapsibleSectionAdapter.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/EditCollapsibleSectionAdapter.kt
@@ -31,13 +31,13 @@ import com.app.playhvz.firebase.classmodels.Game
 class EditCollapsibleSectionAdapter(
     private var items: List<Game.CollapsibleSection>,
     val fragment: Fragment,
-    val onSectionAdded: () -> Unit?
+    val onSectionAdded: () -> Unit?,
+    val onSectionDeleted: (position: Int) -> Unit?
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     companion object {
         private val TAG = EditCollapsibleSectionAdapter::class.qualifiedName
     }
-
 
     private val TYPE_COLLAPSIBLE_SECTION_ITEM = 1
     private val TYPE_ADD = 2
@@ -76,7 +76,8 @@ class EditCollapsibleSectionAdapter(
                 false
             ),
             TitleTextWatcher(),
-            ContentTextWatcher()
+            ContentTextWatcher(),
+            onSectionDeleted
         )
     }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/EditCollapsibleSectionViewHolder.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/rules_faq/EditCollapsibleSectionViewHolder.kt
@@ -17,6 +17,7 @@
 package com.app.playhvz.screens.rules_faq
 
 import android.view.View
+import android.widget.ImageButton
 import androidx.emoji.widget.EmojiEditText
 import androidx.recyclerview.widget.RecyclerView
 import com.app.playhvz.R
@@ -26,13 +27,18 @@ import com.app.playhvz.firebase.classmodels.Game
 class EditCollapsibleSectionViewHolder(
     val view: View,
     val titleTextWatcher: EditCollapsibleSectionAdapter.TitleTextWatcher,
-    val contentTextWatcher: EditCollapsibleSectionAdapter.ContentTextWatcher
+    val contentTextWatcher: EditCollapsibleSectionAdapter.ContentTextWatcher,
+    val onDeleteSection: (position: Int) -> Unit?
 ) : RecyclerView.ViewHolder(view) {
 
     private val sectionTitle = view.findViewById<EmojiEditText>(R.id.section_title)!!
     private val sectionContent = view.findViewById<EmojiEditText>(R.id.section_content)!!
+    private val deleteButton = view.findViewById<ImageButton>(R.id.section_delete_button)!!
 
     fun onBind(position: Int, section: Game.CollapsibleSection) {
+        deleteButton.setOnClickListener {
+            onDeleteSection.invoke(position)
+        }
         titleTextWatcher.setPosition(position)
         contentTextWatcher.setPosition(position)
         sectionTitle.setText(section.sectionTitle)

--- a/Android/ghvzApp/app/src/main/res/layout/card_mission.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/card_mission.xml
@@ -94,7 +94,7 @@
         app:layout_constraintTop_toTopOf="@id/mission_start_time"
         tools:text="Jun 06\n4:00 PM" />
 
-      <com.app.playhvz.common.ui.MarkdownView
+      <com.app.playhvz.common.ui.MarkdownTextView
         android:id="@+id/mission_details"
         style="@style/TextAppearance.MaterialComponents.Body2"
         android:layout_width="wrap_content"

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_chat_room.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_chat_room.xml
@@ -61,7 +61,7 @@
       android:layout_height="wrap_content"
       android:layout_marginBottom="8dp"
       android:layout_weight="1"
-      android:inputType="textAutoCorrect|textCapSentences"
+      android:inputType="textAutoCorrect|textCapSentences|textMultiLine"
       android:maxHeight="124dp"
       android:minHeight="52dp"
       android:orientation="vertical" />

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_chat_room.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_chat_room.xml
@@ -61,6 +61,7 @@
       android:layout_height="wrap_content"
       android:layout_marginBottom="8dp"
       android:layout_weight="1"
+      android:inputType="textAutoCorrect|textCapSentences"
       android:maxHeight="124dp"
       android:minHeight="52dp"
       android:orientation="vertical" />

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_game_settings.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_game_settings.xml
@@ -43,6 +43,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:hint="@string/game_settings_game_name_hint_text"
+    android:inputType="textCapSentences|textNoSuggestions"
     android:maxLength="40"
     android:maxLines="1" />
 

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
@@ -167,6 +167,7 @@
       android:layout_gravity="top"
       android:background="@drawable/rectangular_border"
       android:gravity="start|top"
+      android:inputType="textAutoCorrect|textCapSentences"
       android:lines="12" />
 
     <Button

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_mission_settings.xml
@@ -15,7 +15,6 @@
   -->
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -137,37 +136,19 @@
         android:text="@string/allegiance_option_everyone" />
     </RadioGroup>
 
-
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <TextView
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      android:text="@string/mission_settings_details_label"
+      android:textSize="18sp" />
 
-      <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/mission_settings_details_label"
-        android:textSize="18sp"
-        app:layout_constraintBottom_toBottomOf="@id/markdown_info_button"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/markdown_info_button" />
-
-      <ImageButton
-        android:id="@+id/markdown_info_button"
-        style="@style/ImageButtonStyle"
-        android:contentDescription="@string/markdown_dialog_trigger_content_description"
-        android:src="@drawable/ic_info"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.emoji.widget.EmojiEditText
+    <com.app.playhvz.common.ui.MarkdownEditText
       android:id="@+id/mission_details"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_gravity="top"
       android:background="@drawable/rectangular_border"
       android:gravity="start|top"
-      android:inputType="textAutoCorrect|textCapSentences"
       android:lines="12" />
 
     <Button

--- a/Android/ghvzApp/app/src/main/res/layout/list_item_collapsible_section_display.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/list_item_collapsible_section_display.xml
@@ -31,7 +31,7 @@
     android:textColor="@color/app_primary_text"
     android:textSize="@dimen/list_item_title_text" />
 
-  <com.app.playhvz.common.ui.MarkdownView
+  <com.app.playhvz.common.ui.MarkdownTextView
     android:id="@+id/section_content"
     style="@style/TextAppearance.MaterialComponents.Body2"
     android:layout_width="match_parent"

--- a/Android/ghvzApp/app/src/main/res/layout/list_item_collapsible_section_edit.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/list_item_collapsible_section_edit.xml
@@ -36,15 +36,7 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
-  <ImageButton
-    android:id="@+id/markdown_info_button"
-    style="@style/ImageButtonStyle"
-    android:contentDescription="@string/markdown_dialog_trigger_content_description"
-    android:src="@drawable/ic_info"
-    app:layout_constraintBottom_toTopOf="@+id/section_content"
-    app:layout_constraintEnd_toEndOf="parent" />
-
-  <androidx.emoji.widget.EmojiEditText
+  <com.app.playhvz.common.ui.MarkdownEditText
     android:id="@+id/section_content"
     style="@style/TextAppearance.MaterialComponents.Body2"
     android:layout_width="match_parent"

--- a/Android/ghvzApp/app/src/main/res/layout/list_item_collapsible_section_edit.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/list_item_collapsible_section_edit.xml
@@ -16,6 +16,7 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:orientation="vertical"
@@ -30,10 +31,22 @@
     android:hint="@string/collapsible_section_title_hint_text"
     android:inputType="textAutoCorrect|textCapSentences"
     android:maxLength="70"
+    android:paddingEnd="@dimen/tap_target_min"
     android:paddingBottom="8dp"
     android:textColor="@color/app_primary_text"
     android:textSize="@dimen/list_item_title_text"
     app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:ignore="RtlSymmetry" />
+
+  <ImageButton
+    android:id="@+id/section_delete_button"
+    style="@style/ImageButtonStyle"
+    android:layout_width="@dimen/tap_target_min"
+    android:layout_height="@dimen/tap_target_min"
+    android:contentDescription="@string/delete_button_content_description"
+    android:src="@drawable/ic_x"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
 
   <com.app.playhvz.common.ui.MarkdownEditText

--- a/Android/ghvzApp/app/src/main/res/layout/list_item_markdown_example.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/list_item_markdown_example.xml
@@ -43,7 +43,7 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="@id/display_text" />
 
-  <com.app.playhvz.common.ui.MarkdownView
+  <com.app.playhvz.common.ui.MarkdownTextView
     android:id="@+id/display_text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"

--- a/Android/ghvzApp/app/src/main/res/values/dimens.xml
+++ b/Android/ghvzApp/app/src/main/res/values/dimens.xml
@@ -31,5 +31,6 @@
   <dimen name="avatar_border_width">3dp</dimen>
 
   <dimen name="list_item_title_text">20sp</dimen>
+  <dimen name="markdown_icon_padding">12dp</dimen>
 
 </resources>

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -151,6 +151,14 @@
     Add some content
   </string>
 
+  <string name="collapsible_section_remove_dialog_title" definition="Title for the delete confirmation dialog.">
+    Really delete section?
+  </string>
+
+  <string name="collapsible_section_remove_dialog_content" definition="Description for the delete confirmation dialog.">
+    This can\'t be undone.
+  </string>
+
   <string name="datetime_dialog_title" definition="Title for the date time selection dialog.">
     Set date and time
   </string>
@@ -495,6 +503,10 @@
 
   <string name="markdown_dialog_trigger_content_description" definition="Content description for the button that opens the markdown cheatsheet.">
     View Markdown hints
+  </string>
+
+  <string name="delete_button_content_description" definition="Content description for a delete button.">
+    Delete
   </string>
 
 


### PR DESCRIPTION
Inlines the markdown hint dialog button into an edit text view we can use everywhere we want to broadcast that this edit text supports markdown.
Adds ability to remove rules/faq sections
Some UI tweaks and makes markdown headings a bit smaller