### PR TITLE
Submit initial implementation of admin figurehead player

### DIFF
--- a/Android/ghvzApp/.idea/navEditor.xml
+++ b/Android/ghvzApp/.idea/navEditor.xml
@@ -73,7 +73,7 @@
                       <LayoutPositions />
                     </value>
                   </entry>
-                  <entry key="nav_adminchat_list_fragment">
+                  <entry key="nav_admin_chat_list_fragment">
                     <value>
                       <LayoutPositions>
                         <option name="myPosition">
@@ -119,6 +119,11 @@
                           </Point>
                         </option>
                       </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="nav_create_chat_with_admin">
+                    <value>
+                      <LayoutPositions />
                     </value>
                   </entry>
                   <entry key="nav_create_game_fragment">

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/playersearch/PlayerAdapter.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/playersearch/PlayerAdapter.kt
@@ -28,7 +28,8 @@ import com.google.android.material.button.MaterialButton
 class PlayerAdapter(
     private var items: List<Player>,
     val context: Context,
-    val playerSelectedClickHandler: PlayerSearchClickHandler
+    val playerSelectedClickHandler: PlayerSearchClickHandler,
+    val maxSelectable: Int? = null
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>(), PlayerViewHolder.PlayerClickListener {
 
@@ -73,7 +74,12 @@ class PlayerAdapter(
             checkIcon.visibility = View.VISIBLE
             checkIcon.isEnabled = true
         }
-        playerSelectedClickHandler.onPlayerClicked(selectedPlayers.isNotEmpty())
+        val allowSubmit = if (maxSelectable != null) {
+            selectedPlayers.isNotEmpty() && selectedPlayers.size <= maxSelectable
+        } else {
+            selectedPlayers.isNotEmpty()
+        }
+        playerSelectedClickHandler.onPlayerClicked(allowSubmit)
     }
 
     fun setData(data: List<Player>) {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/playersearch/PlayerSearchWithinGroupDialog.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/common/playersearch/PlayerSearchWithinGroupDialog.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.app.playhvz.common.playersearch
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.widget.doOnTextChanged
+import androidx.emoji.widget.EmojiEditText
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.app.playhvz.R
+import com.app.playhvz.app.EspressoIdlingResource
+import com.app.playhvz.app.HvzData
+import com.app.playhvz.firebase.classmodels.Group
+import com.app.playhvz.firebase.classmodels.Player
+import com.app.playhvz.firebase.operations.ChatDatabaseOperations
+import com.app.playhvz.firebase.operations.GroupDatabaseOperations
+import com.app.playhvz.utils.PlayerUtils
+import kotlinx.coroutines.runBlocking
+
+class PlayerSearchWithinGroupDialog(val gameId: String, val group: Group?, val onSelectedCallback: (selectedPlayerId: String)->Unit) :
+    DialogFragment(),
+    PlayerAdapter.PlayerSearchClickHandler {
+    companion object {
+        private val TAG = PlayerSearchWithinGroupDialog::class.qualifiedName
+    }
+
+    private lateinit var dialogView: View
+    private lateinit var errorLabel: TextView
+    private lateinit var inputLabel: TextView
+    private lateinit var inputText: EmojiEditText
+    private lateinit var negativeButton: Button
+    private lateinit var positiveButton: Button
+    private lateinit var playerAdapter: PlayerAdapter
+    private lateinit var progressBar: ProgressBar
+
+    private lateinit var playerListLiveData: HvzData<List<Player>>
+
+    private var playerFilter: String? = null
+    private var latestQueryFilter: String? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        playerListLiveData = HvzData(listOf())
+        return super.onCreateDialog(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        dialogView = inflater.inflate(R.layout.dialog_player_search, null)
+        errorLabel = dialogView.findViewById(R.id.error_label)
+        inputLabel = dialogView.findViewById(R.id.dialog_label)
+        inputText = dialogView.findViewById(R.id.dialog_input)
+        negativeButton = dialogView.findViewById(R.id.negative_button)
+        positiveButton = dialogView.findViewById(R.id.positive_button)
+        progressBar = dialogView.findViewById(R.id.progress_bar)
+
+        playerAdapter = PlayerAdapter(listOf(), requireContext(), this, /* maxSelectable= */ 1)
+        val playerRecyclerView: RecyclerView = dialogView.findViewById(R.id.player_list)
+        val layoutManager = LinearLayoutManager(context)
+        playerRecyclerView.layoutManager = layoutManager
+        playerRecyclerView.adapter = playerAdapter
+
+        inputText.doOnTextChanged { text, _, _, _ ->
+            when {
+                text.isNullOrEmpty() -> {
+                    queryPlayers(null)
+                }
+                else -> {
+                    queryPlayers(text.toString())
+                }
+            }
+            errorLabel.visibility = View.GONE
+        }
+
+        queryPlayers(null)
+        initDialogViews()
+
+        playerListLiveData.observe(this, Observer { updatedList ->
+            onPlayerListUpdated(updatedList)
+        })
+
+        return dialogView
+    }
+
+    override fun onPlayerClicked(anyPlayerSelected: Boolean) {
+        positiveButton.isEnabled = anyPlayerSelected
+    }
+
+    private fun queryPlayers(nameFilter: String?) {
+        if (group == null) {
+            return
+        }
+        latestQueryFilter = nameFilter
+        PlayerUtils.getPlayerListInGroup(playerListLiveData, gameId, group, nameFilter)
+    }
+
+    private fun onPlayerListUpdated(updatedList: List<Player>) {
+        val filteredList = updatedList.toMutableList()
+        filteredList.sortBy { player -> player.name }
+
+        val query = latestQueryFilter
+        if (!query.isNullOrEmpty()) {
+            // Filter out players that don't have the right start to their name.
+            for (player in updatedList) {
+                if (!player.name!!.startsWith(query, /* ignoreCase= */ true)) {
+                    filteredList.remove(player)
+                }
+            }
+        }
+        playerAdapter.setData(filteredList)
+        playerAdapter.notifyDataSetChanged()
+    }
+
+    private fun initDialogViews() {
+        errorLabel.visibility = View.GONE
+        inputLabel.setText(getString(R.string.player_search_input_label))
+        positiveButton.isEnabled = false
+        positiveButton.text = getString(R.string.button_set)
+        positiveButton.setOnClickListener {
+            positiveButton.isEnabled = false
+            addSelectedPlayers()
+            this.dismiss()
+        }
+        negativeButton.text = getString(R.string.button_cancel)
+        negativeButton.setOnClickListener {
+            this.dismiss()
+        }
+    }
+
+    private fun addSelectedPlayers() {
+        progressBar.visibility = View.VISIBLE
+        val selectedPlayers = playerAdapter.getSelectedPlayers()
+        onSelectedCallback(selectedPlayers.first())
+    }
+}

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/ChatRoom.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/ChatRoom.kt
@@ -18,10 +18,6 @@ package com.app.playhvz.firebase.classmodels
 
 /** Android data model representing Firebase Chatroom documents. */
 class ChatRoom {
-    companion object {
-        val FIELD__IS_VISIBLE = "isVisible"
-    }
-
     var id: String? = null
 
     // Group id

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Game.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Game.kt
@@ -29,6 +29,10 @@ class Game {
 
     var adminGroupId: String? = null
 
+    var adminOnCallPlayerId: String? = null
+
+    var figureheadAdminPlayerAccount: String? = null
+
     var admins: List<String> = listOf()
 
     var rules: List<CollapsibleSection> = listOf()

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Player.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/classmodels/Player.kt
@@ -23,6 +23,11 @@ import com.google.firebase.Timestamp
 
 /** Android data model representing Firebase Player documents. */
 class Player {
+    companion object {
+        val FIELD__CHAT_MEMBERSHIP_IS_VISIBLE = "isVisible"
+        val FIELD__CHAT_MEMBERSHIP_ALLOW_NOTIFICATIONS = "allowNotifications"
+    }
+
     var id: String? = null
 
     // UserId for the User that owns this player account

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatListViewModel.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/firebase/viewmodels/ChatListViewModel.kt
@@ -22,11 +22,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.app.playhvz.app.HvzData
 import com.app.playhvz.firebase.classmodels.ChatRoom
-import com.app.playhvz.firebase.classmodels.ChatRoom.Companion.FIELD__IS_VISIBLE
+import com.app.playhvz.firebase.classmodels.Player.Companion.FIELD__CHAT_MEMBERSHIP_IS_VISIBLE
 import com.app.playhvz.firebase.operations.ChatDatabaseOperations.Companion.getChatRoomDocumentReference
 import com.app.playhvz.firebase.operations.PlayerDatabaseOperations.Companion.getPlayerDocumentReference
 import com.app.playhvz.firebase.utils.DataConverterUtil
-import com.app.playhvz.utils.ObserverUtils
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.EventListener
@@ -71,7 +70,7 @@ class ChatListViewModel : ViewModel() {
                 val player = DataConverterUtil.convertSnapshotToPlayer(snapshot!!)
                 val updatedChatRoomIds: MutableList<String> = mutableListOf()
                 for ((key, value) in player.chatRoomMemberships) {
-                    if (value.getOrElse(FIELD__IS_VISIBLE) { false }) {
+                    if (value.getOrElse(FIELD__CHAT_MEMBERSHIP_IS_VISIBLE) { false }) {
                         updatedChatRoomIds.add(key)
                     }
                 }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/navigation/NavigationUtil.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/navigation/NavigationUtil.kt
@@ -104,9 +104,9 @@ class NavigationUtil {
         /**
          * Opens the chat's info screen.
          */
-        fun navigateToChatInfo(navController: NavController, chatRoomId: String) {
+        fun navigateToChatInfo(navController: NavController, chatRoomId: String, isChatWithAdmins: Boolean) {
             navController.navigate(
-                ChatInfoFragmentDirections.actionGlobalNavChatInfoFragment(chatRoomId)
+                ChatInfoFragmentDirections.actionGlobalNavChatInfoFragment(chatRoomId, isChatWithAdmins)
             )
         }
 

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/MainActivity.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/MainActivity.kt
@@ -47,6 +47,7 @@ import com.app.playhvz.screens.signin.SignInActivity
 import com.app.playhvz.utils.SystemUtils
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.internal.NavigationMenuItemView
 import com.google.android.material.navigation.NavigationView
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.coroutines.runBlocking
@@ -157,6 +158,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
                 )
             }
             R.id.nav_create_chat_with_admin -> {
+                item.actionView.visibility = View.VISIBLE
                 navigateToAdminChat()
             }
             R.id.nav_game_list_fragment -> {
@@ -203,6 +205,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
 
     private fun setupUI() {
         navDrawerView = findViewById(R.id.nav_view)
+        navDrawerView.menu.findItem(R.id.nav_create_chat_with_admin).actionView.visibility = View.GONE
 
         setupToolbar()
         setupBottomNavigationBar()
@@ -298,6 +301,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
             return
         }
         val onSuccess = { adminChatId: String ->
+            navDrawerView.menu.findItem(R.id.nav_create_chat_with_admin).actionView.visibility = View.GONE
             drawer_layout.closeDrawer(GravityCompat.START)
             NavigationUtil.navigateToChatRoom(getNavController(), adminChatId)
         }

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/ChatRoomFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/ChatRoomFragment.kt
@@ -56,7 +56,6 @@ class ChatRoomFragment : Fragment() {
     lateinit var chatViewModel: ChatRoomViewModel
     lateinit var messageAdapter: MessageAdapter
 
-
     private lateinit var chatRoomId: String
     private lateinit var progressBar: ProgressBar
     private lateinit var messageInputView: EmojiEditText
@@ -66,6 +65,7 @@ class ChatRoomFragment : Fragment() {
     private var gameId: String? = null
     private var playerId: String? = null
     private var toolbar: ActionBar? = null
+    private var isChatWithAdmin: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -142,7 +142,7 @@ class ChatRoomFragment : Fragment() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == R.id.chat_info) {
-            NavigationUtil.navigateToChatInfo(findNavController(), chatRoomId)
+            NavigationUtil.navigateToChatInfo(findNavController(), chatRoomId, isChatWithAdmin)
         }
         return super.onOptionsItemSelected(item)
     }
@@ -173,6 +173,7 @@ class ChatRoomFragment : Fragment() {
             toolbar?.title = updatedChatRoom.name
             messageInputView.hint = getString(R.string.chat_input_hint, updatedChatRoom.name)
         }
+        isChatWithAdmin = updatedChatRoom.withAdmins
     }
 
     private fun onMessagesUpdated(updatedMessageList: List<Message>) {

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/chatinfo/ChatInfoFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/chatinfo/ChatInfoFragment.kt
@@ -183,6 +183,7 @@ class ChatInfoFragment : Fragment() {
                 R.string.chat_info_leave_dialog_confirmation
             )
         leaveConfirmationDialog.setPositiveButtonCallback {
+            progressBar.visibility = View.VISIBLE
             runBlocking {
                 EspressoIdlingResource.increment()
                 ChatDatabaseOperations.asyncRemovePlayerFromChatRoom(
@@ -190,6 +191,7 @@ class ChatInfoFragment : Fragment() {
                     playerId!!,
                     chatRoomId,
                     {
+                        progressBar.visibility = View.GONE
                         NavigationUtil.navigateToChatList(findNavController())
                     },
                     {})

--- a/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/chatinfo/ChatInfoFragment.kt
+++ b/Android/ghvzApp/app/src/main/java/com/app/playhvz/screens/chatroom/chatinfo/ChatInfoFragment.kt
@@ -66,17 +66,18 @@ class ChatInfoFragment : Fragment() {
     private lateinit var memberAdapter: MemberAdapter
     private lateinit var progressBar: ProgressBar
 
-
     private val args: ChatInfoFragmentArgs by navArgs()
     private var gameId: String? = null
     private var group: Group? = null
     private var playerHelper: PlayerHelper = PlayerHelper()
     private var playerId: String? = null
+    private var isChatWithAdmins: Boolean = false
     private var toolbar: ActionBar? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         chatRoomId = args.chatRoomId
+        isChatWithAdmins = args.isChatWithAdmins
         chatViewModel = ChatRoomViewModel()
         memberAdapter =
             MemberAdapter(listOf(), requireContext(), { player -> onRemovePlayerClicked(player) })
@@ -170,11 +171,17 @@ class ChatInfoFragment : Fragment() {
     }
 
     private fun onLeaveClicked() {
-        val leaveConfirmationDialog = ConfirmationDialog(
-            getString(R.string.chat_info_leave_dialog_title, chatViewModel.getChatName()),
-            R.string.chat_info_leave_dialog_description,
-            R.string.chat_info_leave_dialog_confirmation
-        )
+        val dialogDescription = if (isChatWithAdmins) {
+            R.string.chat_info_leave_dialog_with_admins_description
+        } else {
+            R.string.chat_info_leave_dialog_description
+        }
+        val leaveConfirmationDialog =
+            ConfirmationDialog(
+                getString(R.string.chat_info_leave_dialog_title, chatViewModel.getChatName()),
+                dialogDescription,
+                R.string.chat_info_leave_dialog_confirmation
+            )
         leaveConfirmationDialog.setPositiveButtonCallback {
             runBlocking {
                 EspressoIdlingResource.increment()

--- a/Android/ghvzApp/app/src/main/res/layout/fragment_game_settings.xml
+++ b/Android/ghvzApp/app/src/main/res/layout/fragment_game_settings.xml
@@ -60,42 +60,78 @@
     android:layout_height="wrap_content"
     android:text="@string/game_settings_game_name_sublabel" />
 
-  <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/admin_section"
+  <LinearLayout
+    android:id="@+id/items_to_hide_during_creation"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="12dp"
-    android:paddingBottom="12dp">
+    android:orientation="vertical">
 
-    <TextView
-      android:id="@+id/admin_list_label"
-      style="@style/TextInputLabel"
+    <RelativeLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:text="@string/game_settings_admin_list_title"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
+      android:minHeight="@dimen/tap_target_min">
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/admin_list"
+      <TextView
+        android:id="@+id/admin_on_call_title"
+        style="@style/TextInputLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:text="@string/game_settings_admin_on_call_title" />
+
+      <include
+        android:id="@+id/on_call_player"
+        layout="@layout/list_item_player"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/admin_on_call_title"
+        app:layout_constraintStart_toStartOf="parent" />
+
+      <TextView
+        android:id="@+id/admin_on_call_description"
+        style="@style/TextInputSubLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/on_call_player"
+        android:text="@string/game_settings_admin_on_call_description" />
+    </RelativeLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      app:layout_constraintHeight_default="wrap"
-      app:layout_constraintHeight_max="200dp"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/admin_list_label" />
+      android:paddingTop="12dp"
+      android:paddingBottom="12dp">
 
-    <com.google.android.material.button.MaterialButton
-      android:id="@+id/add_admin_button"
-      style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="8dp"
-      android:text="@string/game_settings_add_admin_button"
-      app:icon="@drawable/ic_plus"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/admin_list" />
-  </androidx.constraintlayout.widget.ConstraintLayout>
+      <TextView
+        android:id="@+id/admin_list_label"
+        style="@style/TextInputLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/game_settings_admin_list_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/admin_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintHeight_max="200dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/admin_list_label" />
+
+      <com.google.android.material.button.MaterialButton
+        android:id="@+id/add_admin_button"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/game_settings_add_admin_button"
+        app:icon="@drawable/ic_plus"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/admin_list" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </LinearLayout>
 
 
   <Button

--- a/Android/ghvzApp/app/src/main/res/menu/menu_navigation_drawer.xml
+++ b/Android/ghvzApp/app/src/main/res/menu/menu_navigation_drawer.xml
@@ -14,7 +14,8 @@
   ~ limitations under the License.
   -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <!-- Game Admin options. -->
   <group
@@ -46,7 +47,8 @@
     <item
       android:id="@id/nav_create_chat_with_admin"
       android:icon="@drawable/ic_headset"
-      android:title="@string/navigation_drawer_create_chat_with_admin" />
+      android:title="@string/navigation_drawer_create_chat_with_admin"
+      app:actionViewClass="android.widget.ProgressBar" />
   </group>
 
   <group android:id="@+id/nav_global_options">

--- a/Android/ghvzApp/app/src/main/res/navigation/nav_graph.xml
+++ b/Android/ghvzApp/app/src/main/res/navigation/nav_graph.xml
@@ -205,6 +205,10 @@
       android:name="chatRoomId"
       app:argType="string"
       app:nullable="false" />
+    <argument
+      android:name="isChatWithAdmins"
+      app:argType="boolean"
+      app:nullable="false" />
   </fragment>
 
   <fragment

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -126,6 +126,10 @@
     This can\'t be undone, you\'ll have to ask someone else to add you back.
   </string>
 
+  <string name="chat_info_leave_dialog_with_admins_description" definition="Dialog message informing user they can rejoin chat room after leaving.">
+    You can rejoin, just click chat with an admin again.
+  </string>
+
   <string name="chat_info_leave_dialog_confirmation" definition="Confirmation button for leave chat dialog.">
     Yep, leave
   </string>

--- a/Android/ghvzApp/app/src/main/res/values/strings.xml
+++ b/Android/ghvzApp/app/src/main/res/values/strings.xml
@@ -82,6 +82,10 @@
     Next
   </string>
 
+  <string name="button_set" definition="Button to set field to selected item.">
+    Set
+  </string>
+
   <string name="button_submit" definition="Button to select when saving changes.">
     Submit
   </string>
@@ -253,6 +257,14 @@
 
   <string name="game_settings_add_admin_button" definition="Button text for adding a new admin.">
     Add admin
+  </string>
+
+  <string name="game_settings_admin_on_call_title" definition="Title for section showing admin on call.">
+    Admin On Call
+  </string>
+
+  <string name="game_settings_admin_on_call_description" definition="Description for section showing admin on call.">
+    This is the player account that will get notifications when someone pings the default admin account or tries to \"Chat with an Admin\".
   </string>
 
   <string name="game_settings_delete_dialog_title" definition="Title for delete game dialog.">

--- a/firebaseFunctions/functions/src/data/defaults.ts
+++ b/firebaseFunctions/functions/src/data/defaults.ts
@@ -24,3 +24,5 @@ export const globalZombieChatName = "Horde Chat";
 export const gameAdminChatName = "Admins";
 
 export const allegiance = "undeclared";
+
+export const FIGUREHEAD_ADMIN_NAME = "HvZ CDC";

--- a/firebaseFunctions/functions/src/data/game.ts
+++ b/firebaseFunctions/functions/src/data/game.ts
@@ -21,3 +21,5 @@ export const FIELD__CREATOR_USER_ID = "creatorUserId";
 export const FIELD__RULES = "rules";
 export const FIELD__FAQ = "faq";
 export const FIELD__ADMIN_GROUP_ID = "adminGroupId";
+export const FIELD__ADMIN_ON_CALL_PLAYER_ID = "adminOnCallPlayerId";
+export const FIELD__FIGUREHEAD_ADMIN_PLAYER_ACCOUNT = "figureheadAdminPlayerAccount";

--- a/firebaseFunctions/functions/src/index.ts
+++ b/firebaseFunctions/functions/src/index.ts
@@ -84,8 +84,8 @@ exports.createGame = functions.https.onCall(async (data, context) => {
     [Game.FIELD__CREATOR_USER_ID]: context.auth.uid,
   }
 
-  const gameSnapshot = await db.collection(Game.COLLECTION_PATH).add(gameData)
-  const gameId = gameSnapshot.id
+  const gameRef = await db.collection(Game.COLLECTION_PATH).add(gameData)
+  const gameId = gameRef.id
   await GroupUtils.createManagedGroups(db, context.auth.uid, gameId);
 
   const adminGroupQuery = await db.collection(Game.COLLECTION_PATH)
@@ -97,10 +97,22 @@ exports.createGame = functions.https.onCall(async (data, context) => {
 
   if (!adminGroupQuery.empty && adminGroupQuery.docs.length === 1) {
     const adminGroupId = adminGroupQuery.docs[0].id
-    await gameSnapshot.update({
+    await gameRef.update({
       [Game.FIELD__ADMIN_GROUP_ID]: adminGroupId
     })
   }
+
+  // Create admin on call player
+  const player = Player.create("", Defaults.FIGUREHEAD_ADMIN_NAME);
+  const playerDocRef = await db.collection(Game.COLLECTION_PATH)
+      .doc(gameId)
+      .collection(Player.COLLECTION_PATH)
+      .add(player);
+
+  await GroupUtils.addPlayerToManagedGroups(db, gameId, playerDocRef, /* ignoreAllegiance= */ true)
+  await gameRef.update({
+    [Game.FIELD__FIGUREHEAD_ADMIN_PLAYER_ACCOUNT]: playerDocRef.id
+  })
 
   return gameId;
 });
@@ -171,7 +183,7 @@ exports.joinGame = functions.https.onCall(async (data, context) => {
     .collection(Player.COLLECTION_PATH)
     .add(player));
 
-  await GroupUtils.addPlayerToManagedGroups(db, gameId, playerDocRef)
+  await GroupUtils.addPlayerToManagedGroups(db, gameId, playerDocRef, /* ignoreAllegiance= */ false)
   return gameId
 });
 
@@ -571,10 +583,12 @@ exports.createOrGetChatWithAdmin = functions.https.onCall(async (data, context) 
     .get()
 
   const playerData = playerSnapshot.data()
-  if (playerData === undefined) {
+  const gameData = await (await db.collection(Game.COLLECTION_PATH).doc(gameId).get()).data()
+  if (playerData === undefined || gameData == undefined) {
     return
   }
   const playerChatRoomIds = Object.keys(playerData[Player.FIELD__CHAT_MEMBERSHIPS])
+  const adminPlayerId = gameData[Game.FIELD__FIGUREHEAD_ADMIN_PLAYER_ACCOUNT]
 
   const adminQuerySnapshot = await db.collection(Game.COLLECTION_PATH)
     .doc(gameId)
@@ -590,11 +604,24 @@ exports.createOrGetChatWithAdmin = functions.https.onCall(async (data, context) 
     await playerSnapshot.ref.update({
       [visibilityField]: true
     })
+
+    // "Add" the admin to the chat. Even if they are already in it, this resets their notification
+    // and visibility settings so the chat reappears for them.
+    const adminChatData = await adminChatSnapshot.data()
+    if (adminChatData === undefined) {
+      return adminChatSnapshot.id
+    }
+    await ChatUtils.addPlayerToChat(db,
+                gameId,
+                adminPlayerId,
+                db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Group.COLLECTION_PATH).doc(adminChatData[Chat.FIELD__GROUP_ID]),
+                adminChatSnapshot.id,
+                /* isDocRef= */ true)
     return adminChatSnapshot.id
   }
 
   // Create admin chat since it doesn't exist.
-  const chatName = playerData[Player.FIELD__NAME] + " & HvZ CDC"
+  const chatName = playerData[Player.FIELD__NAME] + " & " + Defaults.FIGUREHEAD_ADMIN_NAME
 
   const settings = Group.createSettings(
     /* addSelf= */ true,
@@ -614,6 +641,17 @@ exports.createOrGetChatWithAdmin = functions.https.onCall(async (data, context) 
   await chatSnapshot.ref.update({
     [Chat.FIELD__WITH_ADMINS]: true
   })
+
+  const createdChatData = await chatSnapshot.data()
+  if (createdChatData === undefined) {
+    return createdChatId
+  }
+  await ChatUtils.addPlayerToChat(db,
+    gameId,
+    adminPlayerId,
+    db.collection(Game.COLLECTION_PATH).doc(gameId).collection(Group.COLLECTION_PATH).doc(createdChatData[Chat.FIELD__GROUP_ID]),
+    createdChatId,
+    /* isDocRef= */ true)
   return createdChatId
 })
 

--- a/firebaseFunctions/functions/src/utils/grouputils.ts
+++ b/firebaseFunctions/functions/src/utils/grouputils.ts
@@ -154,7 +154,7 @@ export async function addPlayerToManagedGroups(db: any, gameId: string, playerDo
       .doc(gameData[Game.FIELD__ADMIN_GROUP_ID])
       .get()
     await groupSnapshot.ref.update({
-      [Group.FIELD__OWNERS]: playerDocSnapshot.id
+      [Group.FIELD__OWNERS]: admin.firestore.FieldValue.arrayUnion(playerDocSnapshot.id)
     })
     await addPlayerToGroup(db, gameId, groupSnapshot, playerDocRef.id)
   }

--- a/firebaseFunctions/functions/src/utils/grouputils.ts
+++ b/firebaseFunctions/functions/src/utils/grouputils.ts
@@ -157,6 +157,10 @@ export async function addPlayerToManagedGroups(db: any, gameId: string, playerDo
       [Group.FIELD__OWNERS]: admin.firestore.FieldValue.arrayUnion(playerDocSnapshot.id)
     })
     await addPlayerToGroup(db, gameId, groupSnapshot, playerDocRef.id)
+    // Also set game creator as default "Admin On Call"
+    gameSnapshot.ref.update({
+      [Game.FIELD__ADMIN_ON_CALL_PLAYER_ID]: playerDocSnapshot.id
+    })
   }
 }
 


### PR DESCRIPTION
Creates a "figurehead" player when creating a game that serves as the blanket admin contact. This allows admins to seamlessly rotate without the player being confused who they are chatting to.
Also adds initial field for setting up a real admin contact id, aka the player that should receive the notifications if someone chats with the fake figurehead admin.
*Almost* allows admins to change who is the real on call admin id, they can select any admin in the admin group, but their selection isn't yet propagated to firestore.
Also doesn't actually implement handling notifications and routing them to the real admin instead of the fake admin yet. 